### PR TITLE
initial session-based approach

### DIFF
--- a/src/pypeh/adapters/outbound/validation/pandera_adapter/dataops.py
+++ b/src/pypeh/adapters/outbound/validation/pandera_adapter/dataops.py
@@ -19,7 +19,7 @@ from pypeh.core.interfaces.outbound.dataops import (
     DataImportInterface,
 )
 from pypeh.core.models.validation_errors import ValidationErrorReport
-from pypeh.core.models.validation_dto import ValidationDTO, ValidationConfig
+from pypeh.core.models.validation_dto import ValidationConfig
 from pypeh.adapters.outbound.validation.pandera_adapter.parsers import parse_config, parse_error_report
 from pypeh.adapters.outbound.persistence.hosts import HostFactory, FileIO
 
@@ -31,11 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 class DataFrameAdapter(ValidationInterface[DataFrame], DataImportInterface[DataFrame]):
-    """
-    DataOpsInterface has process method that can be called like this:
-    `self.process(dto, "validate")`
-    """
-
     data_format = DataFrame
 
     def parse_configuration(self, config: ValidationConfig) -> Mapping:
@@ -47,15 +42,12 @@ class DataFrameAdapter(ValidationInterface[DataFrame], DataImportInterface[DataF
     def cleanup(self):
         self.get_error_collector().clear_errors()
 
-    def validate(self, data: dict[str, list] | DataFrame, config: ValidationConfig) -> ValidationErrorReport:
+    def _validate(self, data: dict[str, list] | DataFrame, config: ValidationConfig) -> ValidationErrorReport:
         config_map = self.parse_configuration(config)
         validator = Validator.config_from_mapping(config=config_map, logger=logger)
         _ = validator.validate(data)
 
         return parse_error_report(self.get_error_collector().get_errors())
-
-    def process(self, dto: ValidationDTO, action: str) -> ValidationErrorReport:
-        return getattr(self, action)(dto.data, dto.config)
 
     def summarize(self, data: Mapping, config: Mapping):
         pass

--- a/src/pypeh/core/interfaces/outbound/dataops.py
+++ b/src/pypeh/core/interfaces/outbound/dataops.py
@@ -11,16 +11,17 @@ from __future__ import annotations
 import logging
 
 from abc import abstractmethod
-from peh_model.peh import DataLayout, EntityList
+from peh_model.peh import DataLayout, EntityList, Observation
 from typing import TYPE_CHECKING, TypeVar, Generic, cast, List
 
+from pypeh.core.cache.containers import CacheContainer
 from pypeh.core.models.settings import FileSystemSettings
 from pypeh.core.models.validation_dto import ValidationConfig
 from pypeh.adapters.outbound.persistence.hosts import HostFactory
 
 if TYPE_CHECKING:
     from typing import Sequence
-    from pypeh.core.models.validation_errors import ValidationErrorReport
+    from pypeh.core.models.validation_errors import ValidationErrorReport, ValidationErrorReportCollection
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +43,20 @@ class OutDataOpsInterface:
 
 class ValidationInterface(OutDataOpsInterface, Generic[T_DataType]):
     @abstractmethod
-    def validate(self, data: dict[str, Sequence] | T_DataType, config: ValidationConfig) -> ValidationErrorReport:
+    def _validate(self, data: dict[str, Sequence] | T_DataType, config: ValidationConfig) -> ValidationErrorReport:
         raise NotImplementedError
+
+    def validate(
+        self, data: dict[str, Sequence] | T_DataType, observation: Observation, cache: CacheContainer
+    ) -> ValidationErrorReportCollection:
+        result_dict: ValidationErrorReportCollection = {}
+        for oep_set_name, validation_config in ValidationConfig.from_observation(
+            observation,
+            cache,
+        ):
+            result_dict[oep_set_name] = self._validate(data, validation_config)
+
+        return result_dict
 
 
 class DataImportInterface(OutDataOpsInterface, Generic[T_DataType]):

--- a/src/pypeh/core/models/validation_dto.py
+++ b/src/pypeh/core/models/validation_dto.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from typing import Any, Dict, Generator
 
 from pypeh.core.models.constants import ValidationErrorLevel
+from pypeh.core.cache.containers import CacheContainer
 from peh_model import peh
 
 
@@ -140,7 +141,7 @@ class ValidationConfig(BaseModel):
         cls,
         oep_set: peh.ObservableEntityPropertySet,
         oep_set_name: str,
-        observable_property_dict: Dict[str, peh.ObservableProperty],
+        cache: CacheContainer,
     ) -> "ValidationConfig":
         if isinstance(oep_set.required_observable_property_id_list, list) and isinstance(
             oep_set.optional_observable_property_id_list, list
@@ -149,16 +150,19 @@ class ValidationConfig(BaseModel):
         else:
             raise TypeError
 
+        observable_property_dict = {}
+        for op_id in all_op_ids:
+            obs_prop = cache.get(op_id, "ObservableProperty")
+            if not isinstance(obs_prop, peh.ObservableProperty):
+                me = f"Provided observable_property_id {op_id} does not point to an ObservableProperty"
+                logger.error(me)
+                raise TypeError(me)
+            observable_property_dict[op_id] = obs_prop
+
         columns = [
             ColumnValidation.from_peh(op_id, observable_property_dict[op_id])
-            for op_id in all_op_ids
-            if op_id in observable_property_dict
+            for op_id in observable_property_dict.keys()
         ]
-
-        # Optional: log or raise error if some op_ids are missing
-        missing = set(all_op_ids) - observable_property_dict.keys()
-        if missing:
-            raise ValueError(f"Missing observable properties for IDs: {missing}")
 
         assert isinstance(oep_set.identifying_observable_property_id_list, list)
         return cls(
@@ -172,7 +176,7 @@ class ValidationConfig(BaseModel):
     def from_observation(
         cls,
         observation: peh.Observation,
-        observable_property_dict: dict[str, peh.ObservableProperty],
+        cache: CacheContainer,
     ) -> Generator[tuple[str, ValidationConfig], None, None]:
         observation_design = observation.observation_design
         observable_entity_property_sets = getattr(observation_design, "observable_entity_property_sets", None)
@@ -188,7 +192,7 @@ class ValidationConfig(BaseModel):
                 ValidationConfig.from_peh(
                     oep_set,
                     oep_set_name,
-                    observable_property_dict,
+                    cache,
                 ),
             )
 

--- a/src/pypeh/core/models/validation_errors.py
+++ b/src/pypeh/core/models/validation_errors.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, TypedDict
 from pydantic import BaseModel, Field
 
 from pypeh.core.models.constants import ValidationErrorLevel
@@ -60,3 +60,8 @@ class ValidationErrorReport(BaseModel):
     error_counts: Dict[ValidationErrorLevel, int] = Field(default_factory=dict)
     groups: List[ValidationErrorGroup] = Field(default_factory=list)
     unexpected_errors: List[ValidationError] = Field(default_factory=list)
+
+
+class ValidationErrorReportCollection(TypedDict, total=False):
+    observable_property_set: str
+    report: ValidationErrorReport

--- a/src/pypeh/core/services/dataops.py
+++ b/src/pypeh/core/services/dataops.py
@@ -2,19 +2,15 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING, Sequence
-from peh_model import peh
+from typing import TYPE_CHECKING
 
 from pypeh.core.interfaces.inbound.dataops import InDataOpsInterface
 from pypeh.core.interfaces.outbound.dataops import OutDataOpsInterface, ValidationInterface
-from pypeh.core.interfaces.outbound.persistence import PersistenceInterface
-from pypeh.core.models.settings import SettingsConfig
 from pypeh.core.cache.containers import CacheContainer, CacheContainerFactory
-from pypeh.core.models.validation_dto import ValidationConfig
 
 
 if TYPE_CHECKING:
-    from polars import DataFrame
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -40,76 +36,3 @@ class ValidationService(DataOpsService):
     ):
         super().__init__(inbound_adapter, outbound_adapter, cache)
         self.outbound_adapter: ValidationInterface = outbound_adapter
-
-    def _validate_data(
-        self,
-        data: dict[str, Sequence] | DataFrame,
-        observation: peh.Observation,
-        observable_property_dict: dict[str, peh.ObservableProperty],
-    ) -> dict:
-        result_dict = {}
-        for oep_set_name, validation_config in ValidationConfig.from_observation(
-            observation,
-            observable_property_dict,
-        ):
-            result_dict[oep_set_name] = self.outbound_adapter.validate(data, validation_config)
-
-        return result_dict
-
-    def validate_data(
-        self,
-        data: dict[str, Sequence] | DataFrame,
-        observation_id: str,
-        observable_property_id_list: list[str],
-    ) -> dict:
-        observation_entity = self.cache.get(observation_id, "Observation")
-        if not isinstance(observation_entity, peh.Observation):
-            me = f"Provided observation_id {observation_id} does not point to an Observation"
-            logger.error(me)
-            raise TypeError(me)
-        observable_property_dict = {}
-
-        for _id in observable_property_id_list:
-            entity = self.cache.get(_id, "ObservableProperty")
-            if not isinstance(entity, peh.ObservableProperty):
-                me = f"Provided observable_property_id {_id} does not point to an ObservableProperty"
-                logger.error(me)
-                raise TypeError(me)
-            observable_property_dict[_id] = entity
-
-        return self._validate_data(
-            data,
-            observation_entity,
-            observable_property_dict,
-        )
-
-
-class DataImportService(DataOpsService):
-    def __init__(
-        self,
-        outbound_adapter: PersistenceInterface,
-        inbound_adapter: InDataOpsInterface | None = None,
-        cache: CacheContainer = CacheContainerFactory.new(),
-    ):
-        super().__init__(inbound_adapter, outbound_adapter, cache)
-        self.outbound_adapter: PersistenceInterface = outbound_adapter
-
-    def import_data(
-        self, source: str, config: SettingsConfig, data_layout: str, layout_config: SettingsConfig | None = None
-    ):
-        # validate config
-        settings = config.make_settings()
-        if layout_config is not None:
-            layout_settings = layout_config.make_settings()
-        else:
-            layout_settings = settings
-
-        # import layout and extract info
-        layout_object = self.outbound_adapter.import_data_layout(
-            data_layout,
-            layout_settings,
-        )
-        # import data
-        # verify data with layout
-        data = self.outbound_adapter.load(source, validation_layout=layout_object)
-        return data

--- a/src/pypeh/core/session/session.py
+++ b/src/pypeh/core/session/session.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 import os
 
-from peh_model.peh import DataLayout
+from peh_model.peh import DataLayout, Observation, NamedThing
+from typing import TYPE_CHECKING, cast
 
+from pypeh.adapters.outbound.validation.pandera_adapter.dataops import DataFrameAdapter
 from pypeh.core.cache.containers import CacheContainer, CacheContainerFactory
+from pypeh.core.models.proxy import TypedLazyProxy
 from pypeh.core.models.settings import (
     LocalFileConfig,
     ImportConfig,
@@ -14,20 +17,17 @@ from pypeh.core.models.settings import (
     ValidatedImportConfig,
 )
 from pypeh.core.models.typing import T_NamedThingLike
-from pypeh.core.models.validation_errors import ValidationError, ValidationErrorLevel
-
-from typing import TYPE_CHECKING
-
+from pypeh.core.models.validation_errors import ValidationError, ValidationErrorLevel, ValidationErrorReportCollection
 from pypeh.adapters.outbound.persistence.hosts import HostFactory, LocalStorageProvider
 from pypeh.core.interfaces.outbound.persistence import PersistenceInterface
-
 from pypeh.core.cache.utils import load_entities_from_tree
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from typing import Dict
+    from polars import DataFrame
     from pydantic_settings import BaseSettings
+    from typing import Dict, Sequence
 
 
 class Session:
@@ -158,21 +158,17 @@ class Session:
 
         return ret
 
-    def load_resource(self, resource_identifier: str, resource_type: str) -> T_NamedThingLike | None:
+    def resolve_typed_lazy_proxy(self, proxy: TypedLazyProxy) -> NamedThing:
+        raise NotImplementedError()
+
+    def load_resource(self, resource_identifier: str, resource_type: str) -> NamedThing | None:
         """Load resource into cache. First checks the cache,
         then configured persisted cache, and finally the `ImportConfig`"""
-        # cache
         ret = self.get_resource(resource_identifier, resource_type)
+        if isinstance(ret, TypedLazyProxy):
+            ret = self.resolve_typed_lazy_proxy(ret)
         if ret is not None:
             return ret
-        # setup ContextService
-
-        # TODO: check importmap and create connection
-        # if self.import_config is not None:
-        # connection = self.import_config.get_connection(resource_identifier)
-        # connection.do_stuff()
-
-        # TODO: final step resolve as linked data
 
         return ret
 
@@ -184,3 +180,27 @@ class Session:
 
     def dump_project(self, project_identifier: str, version: str | None) -> bool:
         return self.dump_resource(project_identifier, resource_type="Project", version=version)
+
+    def validate_tabular_data(
+        self,
+        data: dict[str, Sequence] | DataFrame,
+        observation: Observation | None = None,
+        observation_id: str | None = None,
+    ) -> ValidationErrorReportCollection:
+        # input checks
+        if observation is None and observation_id is None:
+            raise ValueError("Either observation or observation_id should be provided")
+        elif observation is not None and observation_id is not None:
+            raise ValueError("Either observation or observation_id should be provided")
+
+        # make objects
+        if observation_id is not None:
+            resource = self.load_resource(observation_id, "Observation")
+            if not isinstance(resource, Observation):
+                raise TypeError(f"Resource with id {observation_id} did not return an Observation object")
+            observation = cast(Observation, resource)
+
+        assert observation is not None
+        # run validation
+        adapter = DataFrameAdapter()
+        return adapter.validate(data, observation, self.cache)


### PR DESCRIPTION
Initial refactor to move service logic in part to session and in part to validation interface.
Note that the input for validation is still an observation and not an observation design (legacy).
Currently this cannot be turned into an observation design yet I think as this is not a `NamedThing`. Currently the cache only receives objects that inherit from `NamedThing`