### PR TITLE
load_tabular_data with HostFactory

### DIFF
--- a/src/pypeh/adapters/outbound/persistence/hosts.py
+++ b/src/pypeh/adapters/outbound/persistence/hosts.py
@@ -120,8 +120,8 @@ class DirectoryIO(HostAdapter):
         self, source: Union[str, pathlib.Path], format: Optional[str] = None, maxdepth: int = 1, **load_options
     ) -> Any:
         full_source = self._resolve_path(source)
-        file_io = FileIO(file_system=self.file_system)
         if self.file_system.isfile(full_source):
+            file_io = FileIO(file_system=self.file_system)
             return file_io.load(full_source, format=format, **load_options)
         elif self.file_system.isdir(full_source):
             return list(self.walk(source=source, format=format, maxdepth=maxdepth, **load_options))

--- a/src/pypeh/core/interfaces/outbound/persistence.py
+++ b/src/pypeh/core/interfaces/outbound/persistence.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class PersistenceInterface:
     @abstractmethod
-    def load(self, source: str, validation_layout: DataLayout = None, **kwargs):
+    def load(self, source: str, validation_layout: DataLayout | None = None, **kwargs):
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/core/session/test_session_validation.py
+++ b/tests/core/session/test_session_validation.py
@@ -1,8 +1,9 @@
 import pytest
+import pathlib
+
+from peh_model.peh import DataLayout
 
 from pypeh import Session
-
-from pypeh.adapters.outbound.persistence.serializations import ExcelIO
 from pypeh.core.models.validation_errors import ValidationError
 
 from tests.test_utils.dirutils import get_absolute_path
@@ -10,17 +11,24 @@ from tests.test_utils.dirutils import get_absolute_path
 
 @pytest.mark.dataframe
 class TestSessionValidation:
-    def test_invalid_file(self):
+    def test_invalid_file(self, monkeypatch):
+        monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_TYPE", "LocalFile")
+        monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_ROOT_FOLDER", get_absolute_path("./input/validation_config"))
         excel_path = get_absolute_path("./input/validation_files/invalid_excel.xlsx")
+        assert pathlib.Path(excel_path).is_file()
+
         session = Session()
-        result = session.load_tabular_data(ExcelIO, excel_path)
+        result = session.load_tabular_data(source=excel_path)
         assert isinstance(result, ValidationError)
         assert result.type == "File Processing Error"
 
-    def test_valid_file(self):
+    def test_valid_file(self, monkeypatch):
+        monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_TYPE", "LocalFile")
+        monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_ROOT_FOLDER", get_absolute_path("./input/validation_config"))
         excel_path = get_absolute_path("./input/validation_files/valid_excel_wrong_format.xlsx")
+
         session = Session()
-        result = session.load_tabular_data(ExcelIO, excel_path)
+        result = session.load_tabular_data(source=excel_path)
         assert isinstance(result, dict)
         assert len(result) == 1
 
@@ -33,6 +41,7 @@ class TestSessionValidation:
         session.load_persisted_cache()
         layout = session.cache.get("TEST_DATA_LAYOUT", "DataLayout")
         assert layout is not None
-        result = session.load_tabular_data(ExcelIO, excel_path, validation_layout=layout)
+        assert isinstance(layout, DataLayout)
+        result = session.load_tabular_data(source=excel_path, validation_layout=layout)
         assert isinstance(result, ValidationError)
         assert result.type == "File Processing Error"

--- a/tests/end_to_end/validation/test_dataframe_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_validation.py
@@ -1,19 +1,18 @@
 import pytest
+import peh_model.peh as peh
 
 from tests.test_utils.dirutils import get_absolute_path
 
 from pypeh import Session
-
 from pypeh.core.services.dataops import ValidationService
-from pypeh.adapters.outbound.persistence.serializations import ExcelIO
-from pypeh.adapters.outbound.validation.pandera_adapter.dataops import DataFrameAdapter
-
 from pypeh.core.models.validation_errors import ValidationErrorReport
 
 
 @pytest.mark.end_to_end
 class TestSessionDefaultLocalFile:
     def test_end_to_end_dataframe_validation(self, monkeypatch):
+        from pypeh.adapters.outbound.validation.pandera_adapter.dataops import DataFrameAdapter
+
         monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_TYPE", "LocalFile")
         monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_ROOT_FOLDER", get_absolute_path("./input/test_01/config"))
 
@@ -21,14 +20,23 @@ class TestSessionDefaultLocalFile:
         session.load_persisted_cache()
 
         layout = session.cache.get("peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA", "DataLayout")
+        assert isinstance(layout, peh.DataLayout)
         observation = session.cache.get("peh:VALIDATION_TEST_SAMPLE_METADATA", "Observation")
-        observable_property_dict = {op.id: op for op in session.cache.get_all("ObservableProperty")}
+        assert isinstance(observation, peh.Observation)
+        observable_property_dict = {}
+        for op in session.cache.get_all("ObservableProperty"):
+            assert isinstance(op.id, str)
+            assert isinstance(op, peh.ObservableProperty)
+            observable_property_dict[op.id] = op
 
+        excel_path = get_absolute_path("./input/test_01/validation_test_01_data.xlsx")
         data_dict = session.load_tabular_data(
-            ExcelIO, get_absolute_path("./input/test_01/validation_test_01_data.xlsx"), validation_layout=layout
+            source=excel_path,
+            validation_layout=layout,
         )
+        assert isinstance(data_dict, dict)
         data_df = data_dict["SAMPLE"]
-
+        assert data_df is not None
         validation_service = ValidationService(outbound_adapter=DataFrameAdapter(), cache=session.cache)
         validation_result = validation_service._validate_data(
             data_df, observation=observation, observable_property_dict=observable_property_dict


### PR DESCRIPTION
Removes `persistence_interface` argument from `Session.load_tabular_data`. `Connection_id` argument needs a follow up pr.