### PR TITLE
session-based validation

### DIFF
--- a/src/pypeh/adapters/outbound/validation/pandera_adapter/dataops.py
+++ b/src/pypeh/adapters/outbound/validation/pandera_adapter/dataops.py
@@ -19,7 +19,7 @@ from pypeh.core.interfaces.outbound.dataops import (
     DataImportInterface,
 )
 from pypeh.core.models.validation_errors import ValidationErrorReport
-from pypeh.core.models.validation_dto import ValidationDTO, ValidationConfig
+from pypeh.core.models.validation_dto import ValidationConfig
 from pypeh.adapters.outbound.validation.pandera_adapter.parsers import parse_config, parse_error_report
 from pypeh.adapters.outbound.persistence.hosts import HostFactory, FileIO
 
@@ -31,11 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 class DataFrameAdapter(ValidationInterface[DataFrame], DataImportInterface[DataFrame]):
-    """
-    DataOpsInterface has process method that can be called like this:
-    `self.process(dto, "validate")`
-    """
-
     data_format = DataFrame
 
     def parse_configuration(self, config: ValidationConfig) -> Mapping:
@@ -47,15 +42,12 @@ class DataFrameAdapter(ValidationInterface[DataFrame], DataImportInterface[DataF
     def cleanup(self):
         self.get_error_collector().clear_errors()
 
-    def validate(self, data: dict[str, list] | DataFrame, config: ValidationConfig) -> ValidationErrorReport:
+    def _validate(self, data: dict[str, list] | DataFrame, config: ValidationConfig) -> ValidationErrorReport:
         config_map = self.parse_configuration(config)
         validator = Validator.config_from_mapping(config=config_map, logger=logger)
         _ = validator.validate(data)
 
         return parse_error_report(self.get_error_collector().get_errors())
-
-    def process(self, dto: ValidationDTO, action: str) -> ValidationErrorReport:
-        return getattr(self, action)(dto.data, dto.config)
 
     def summarize(self, data: Mapping, config: Mapping):
         pass

--- a/src/pypeh/core/interfaces/outbound/dataops.py
+++ b/src/pypeh/core/interfaces/outbound/dataops.py
@@ -7,11 +7,12 @@ Usage: TODO: add usage info
 """
 
 from __future__ import annotations
+import importlib
 
 import logging
 
 from abc import abstractmethod
-from peh_model.peh import DataLayout, EntityList
+from peh_model.peh import DataLayout, EntityList, Observation, ObservableProperty
 from typing import TYPE_CHECKING, TypeVar, Generic, cast, List
 
 from pypeh.core.models.settings import FileSystemSettings
@@ -20,7 +21,7 @@ from pypeh.adapters.outbound.persistence.hosts import HostFactory
 
 if TYPE_CHECKING:
     from typing import Sequence
-    from pypeh.core.models.validation_errors import ValidationErrorReport
+    from pypeh.core.models.validation_errors import ValidationErrorReport, ValidationErrorReportCollection
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +43,34 @@ class OutDataOpsInterface:
 
 class ValidationInterface(OutDataOpsInterface, Generic[T_DataType]):
     @abstractmethod
-    def validate(self, data: dict[str, Sequence] | T_DataType, config: ValidationConfig) -> ValidationErrorReport:
+    def _validate(self, data: dict[str, Sequence] | T_DataType, config: ValidationConfig) -> ValidationErrorReport:
         raise NotImplementedError
+
+    @classmethod
+    def get_default_adapter_class(cls):
+        try:
+            adapter_module = importlib.import_module("pypeh.adapters.outbound.validation.pandera_adapter.dataops")
+            adapter_class = getattr(adapter_module, "DataFrameAdapter")
+        except Exception as e:
+            logger.error("Exception encountered while attempting to import a Pandera-based DataFrameAdapter")
+            raise e
+        return adapter_class
+
+    def validate(
+        self,
+        data: dict[str, Sequence] | T_DataType,
+        observation: Observation,
+        observable_properties: List[ObservableProperty],
+    ) -> ValidationErrorReportCollection:
+        observable_property_dict = {op.id: op for op in observable_properties}
+        result_dict: ValidationErrorReportCollection = {}
+        for oep_set_name, validation_config in ValidationConfig.from_observation(
+            observation,
+            observable_property_dict,
+        ):
+            result_dict[oep_set_name] = self._validate(data, validation_config)
+
+        return result_dict
 
 
 class DataImportInterface(OutDataOpsInterface, Generic[T_DataType]):

--- a/src/pypeh/core/models/settings.py
+++ b/src/pypeh/core/models/settings.py
@@ -5,7 +5,7 @@ import logging
 
 from abc import abstractmethod
 from pydantic_settings import BaseSettings, SettingsConfigDict, PydanticBaseSettingsSource
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError
 from typing import Optional, Type, TypeVar, Generic, cast
 
 from pypeh.core.utils.namespaces import ImportMap

--- a/src/pypeh/core/models/validation_errors.py
+++ b/src/pypeh/core/models/validation_errors.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, TypedDict
 from pydantic import BaseModel, Field
 
 from pypeh.core.models.constants import ValidationErrorLevel
@@ -60,3 +60,8 @@ class ValidationErrorReport(BaseModel):
     error_counts: Dict[ValidationErrorLevel, int] = Field(default_factory=dict)
     groups: List[ValidationErrorGroup] = Field(default_factory=list)
     unexpected_errors: List[ValidationError] = Field(default_factory=list)
+
+
+class ValidationErrorReportCollection(TypedDict, total=False):
+    observable_property_set: str
+    report: ValidationErrorReport

--- a/tests/core/interfaces/outbound/dataops/test_dataops.py
+++ b/tests/core/interfaces/outbound/dataops/test_dataops.py
@@ -4,7 +4,7 @@ import abc
 from typing import Protocol, Any, Generic
 from peh_model.peh import DataLayout
 
-from pypeh.core.interfaces.outbound.dataops import T_DataType
+from pypeh.core.interfaces.outbound.dataops import T_DataType, ValidationInterface
 from pypeh.core.models.validation_errors import ValidationErrorReport
 from pypeh.core.models.constants import ValidationErrorLevel
 from pypeh.core.models.validation_dto import (
@@ -34,6 +34,12 @@ class TestValidation(abc.ABC):
     def get_adapter(self) -> DataOpsProtocol:
         """Return the adapter implementation to test."""
         raise NotImplementedError
+
+    def test_getting_default_adapter_from_interface(self):
+        adapter_class = ValidationInterface.get_default_adapter_class()
+        adapter = adapter_class()
+        assert isinstance(adapter, ValidationInterface)
+        assert isinstance(adapter, type(self.get_adapter()))
 
     def test_validate(self):
         adapter = self.get_adapter()
@@ -77,7 +83,7 @@ class TestValidation(abc.ABC):
             ],
         )
 
-        result = adapter.validate(data, config)
+        result = adapter._validate(data, config)
 
         assert result is not None
         assert result.total_errors == 3

--- a/tests/end_to_end/validation/test_dataframe_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_validation.py
@@ -4,15 +4,12 @@ import peh_model.peh as peh
 from tests.test_utils.dirutils import get_absolute_path
 
 from pypeh import Session
-from pypeh.core.services.dataops import ValidationService
 from pypeh.core.models.validation_errors import ValidationErrorReport
 
 
 @pytest.mark.end_to_end
 class TestSessionDefaultLocalFile:
     def test_end_to_end_dataframe_validation(self, monkeypatch):
-        from pypeh.adapters.outbound.validation.pandera_adapter.dataops import DataFrameAdapter
-
         monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_TYPE", "LocalFile")
         monkeypatch.setenv("DEFAULT_PERSISTED_CACHE_ROOT_FOLDER", get_absolute_path("./input/test_01/config"))
 
@@ -21,13 +18,6 @@ class TestSessionDefaultLocalFile:
 
         layout = session.cache.get("peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA", "DataLayout")
         assert isinstance(layout, peh.DataLayout)
-        observation = session.cache.get("peh:VALIDATION_TEST_SAMPLE_METADATA", "Observation")
-        assert isinstance(observation, peh.Observation)
-        observable_property_dict = {}
-        for op in session.cache.get_all("ObservableProperty"):
-            assert isinstance(op.id, str)
-            assert isinstance(op, peh.ObservableProperty)
-            observable_property_dict[op.id] = op
 
         excel_path = get_absolute_path("./input/test_01/validation_test_01_data.xlsx")
         data_dict = session.load_tabular_data(
@@ -37,10 +27,8 @@ class TestSessionDefaultLocalFile:
         assert isinstance(data_dict, dict)
         data_df = data_dict["SAMPLE"]
         assert data_df is not None
-        validation_service = ValidationService(outbound_adapter=DataFrameAdapter(), cache=session.cache)
-        validation_result = validation_service._validate_data(
-            data_df, observation=observation, observable_property_dict=observable_property_dict
-        )
+
+        validation_result = session.validate_tabular_data(data_df, observation_id="peh:VALIDATION_TEST_SAMPLE_METADATA")
 
         report_to_check = list(validation_result.values())[0]
 


### PR DESCRIPTION
Another variation, with some differences on the adapter registration and config.
The Session and ValidationInterface is where it all happens. AdapterConfig and ValidationService were left out for now.
The session keeps a register of adapters. The interface can provide its preferred/default adapter implementation.

To be finetuned (later?):
- option to instantiate a session or services with an adapter_config parameter
- loading in one or more adapter configs from envvars
- agree on a better way to link interfaces/functionality with the adapter they should be executed with
- chicken-and-egg solution (dynamic plugin / dynamic config / in-code self-registration by adapter) and/or adopt an injection library
- the last two can drive towards explicit typing on the adapter registry