### PR TITLE
setup data model

### DIFF
--- a/src/pypeh/core/cache/containers.py
+++ b/src/pypeh/core/cache/containers.py
@@ -21,7 +21,7 @@ from pypeh.core.cache.utils import get_entity_type
 from pypeh.core.models.proxy import TypedLazyProxy
 
 if TYPE_CHECKING:
-    from typing import Optional, Generator
+    from typing import Optional, Generator, Sequence
     from pypeh.core.models.typing import T_NamedThingLike
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class CacheContainer(ABC, Generic[T_Container]):
         pass
 
     @abstractmethod
-    def get(self, entity_id: str, entity_type: str) -> T_NamedThingLike:
+    def get(self, entity_id: str, entity_type: str | None = None) -> T_NamedThingLike:
         """Retrieve an entity"""
         pass
 
@@ -56,7 +56,7 @@ class CacheContainer(ABC, Generic[T_Container]):
         pass
 
     @abstractmethod
-    def exists(self, entity_id: str, entity_type: str) -> bool:
+    def exists(self, entity_id: str, entity_type: str | None = None) -> bool:
         """Clear all stored data"""
         pass
 
@@ -70,6 +70,40 @@ class CacheContainer(ABC, Generic[T_Container]):
         pass
 
 
+class CacheContainerView(Generic[T_Container]):
+    """Immutable view of any CacheContainer that only exposes read operations."""
+
+    def __init__(self, container: CacheContainer[T_Container], container_subset: Sequence | None = None):
+        self._container = container
+        self.container_subset = container_subset
+
+    def exists(self, entity_id: str, entity_type: str) -> bool:
+        return self._container.exists(entity_id, entity_type)
+
+    def get(self, entity_id: str, entity_type: str | None = None) -> Optional[T_NamedThingLike]:
+        return self._container.get(entity_id, entity_type)
+
+    def get_all(self, entity_type: str | None = None) -> Generator[T_NamedThingLike, None, None]:
+        return self._container.get_all(entity_type)
+
+    def iterate_subset(self) -> Generator[T_NamedThingLike, None, None]:
+        if self.container_subset is not None:
+            for entity_id in self.container_subset:
+                ret = self.get(entity_id)
+                if ret is not None:
+                    yield ret
+                else:
+                    logger.debug(f"Entity with id {entity_id} not found in cache")
+        else:
+            logger.debug("No container_subset was provided")
+
+    def __len__(self) -> int:
+        return len(self._container)
+
+    def __repr__(self):
+        return f"ImmutableCacheContainerView({self._container!r})"
+
+
 class MappingContainer(CacheContainer[Dict]):
     def __init__(self):
         self._storage: Dict[str, T_NamedThingLike] = dict()
@@ -79,10 +113,10 @@ class MappingContainer(CacheContainer[Dict]):
         self._storage[entity_id] = entity
         self._class_index[entity_type].add(entity_id)
 
-    def exists(self, entity_id: str, entity_type: str) -> bool:
+    def exists(self, entity_id: str, entity_type: str | None = None) -> bool:
         return entity_id in self._storage.keys()
 
-    def _get(self, entity_id: str, entity_type: str) -> Optional[T_NamedThingLike]:
+    def _get(self, entity_id: str, entity_type: str | None = None) -> Optional[T_NamedThingLike]:
         if self.exists(entity_id, entity_type):
             return self._storage[entity_id]
 
@@ -96,7 +130,7 @@ class MappingContainer(CacheContainer[Dict]):
                 return
         return self._add_object(entity, entity.id, class_name)
 
-    def get(self, entity_id: str, entity_type: str) -> Optional[T_NamedThingLike]:
+    def get(self, entity_id: str, entity_type: str | None = None) -> Optional[T_NamedThingLike]:
         ret = self._get(entity_id, entity_type)
         if ret is None:
             message = f"Storage error: Object of class '{entity_type}' with id '{entity_id}' not found."

--- a/src/pypeh/core/models/tabular_data.py
+++ b/src/pypeh/core/models/tabular_data.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+
+from collections import defaultdict
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING
+
+from pypeh.core.cache.containers import CacheContainerView
+from pypeh.core.models.constants import ObservablePropertyValueType
+
+if TYPE_CHECKING:
+    from polars import DataFrame
+
+logger = logging.getLogger(__name__)
+
+
+class Column(BaseModel):
+    label: str
+    datatype: str | None = None
+    observable_property_id: str
+    table_id: str | None = None
+
+
+class Table(BaseModel):
+    id: str
+    label: str
+    columns: dict[str, Column] = Field(default_factory=dict, description="Column label to column map")
+    schema: dict[str, str] | None = Field(None, description="Column label to datatype mapping")
+    observation_id: str
+
+    def model_post_init(self, __context):
+        for column in self.columns.values():
+            column.table_id = self.id
+
+    def _add_column(self, column: Column):
+        self.columns[column.label] = column
+        column.table_id = self.id
+
+
+class TableGroup(dict[str, Table]):
+    """Metadata on a collection of dataframes comprising a single dataset"""
+
+
+class DataSet:
+    def __init__(self, data: dict[str, DataFrame], cache_view: CacheContainerView):
+        self.data = dict[str, DataFrame]
+        self.metadata: TableGroup = self.collect_metadata(cache_view)
+
+        # label-based view on the DataSet
+        self._label_index: dict[str, set[str]] = defaultdict(set)
+
+    def _add_table(self):
+        pass
+
+    def _add_column(self):
+        pass
+
+    def get_table_by_label(self, label: str) -> Table:
+        pass
+
+    def get_column_by_label(self, label: str, table_label: str) -> Column:
+        pass
+
+    def collect_metadata(self, cache_view: CacheContainerView) -> TableGroup:
+        pass
+
+    def collect_schema(self, cache_view: CacheContainerView) -> dict[str, dict[str, ObservablePropertyValueType]]:
+        ret = {}
+
+        # filter out DataLayout or DataLayoutSections
+
+        """
+        sections = getattr(layout, "sections")
+        if sections is None:
+            raise ValueError("No sections found in DataLayout")
+        for section in sections:
+            label = getattr(section, "ui_label")
+            elements = getattr(section, "elements")
+            if elements is None:
+                logger.info("DataLayout does not contain elements. Cannot determine observable_entity_value_types.")
+                return None
+            for element in elements:
+                element_label = getattr(element, "label")
+                observable_property_id = getattr(element, "observable_property")
+                observable_property = self.cache.get(observable_property_id, "ObservableProperty")
+                if observable_property is None:
+                    logger.info(
+                        f"Could not find {observable_property_id} in cache. Cannot determine observable_property_value_types. "
+                    )
+                    return None
+                assert isinstance(label, str)
+                value_type = getattr(observable_property, "value_type")
+                if flatten:
+                    ret[element_label] = ObservablePropertyValueType(value_type)
+                else:
+                    if label not in ret:
+                        ret[label] = {}
+                    ret[label][element_label] = ObservablePropertyValueType(value_type)
+
+        """
+        return ret


### PR DESCRIPTION
First attempt at trying to avoid various mappings that are currently required to link `DataLayout`s and their downstream classes with `Observation`s and their downstream classes by tightening the link between them. This would mean that a dataset would get imported as a `DataSet` object rather than as a `dict[str, DataFrame]`.

This already introduces the idea of CacheViews (see #92) but can be kept out of this PR.

I would not only welcome feedback on the idea but also on the naming of the classes.
`Table` and `Column` currently carry the label (and id) of the `DataLayoutSection`s and `DataLayoutElement`s, so this is potentially quite confusing.