### PR TITLE
Use Entity IDs where possible in validation error reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ default-groups = [
 ]
 
 [tool.uv.sources]
-dataguard = { git = "https://github.com/eu-parc/dataguard.git", tag = "v0.4.2" }
+dataguard = { git = "https://github.com/eu-parc/dataguard.git", tag = "v0.4.3" }
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/pypeh/core/models/validation_errors.py
+++ b/src/pypeh/core/models/validation_errors.py
@@ -1,7 +1,7 @@
 import json
 
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Tuple, Literal, Optional, Union
 from pydantic import BaseModel, Field, field_serializer
 from typing_extensions import Annotated
 
@@ -23,6 +23,14 @@ class DataFrameLocation(ValidationErrorLocation):
     row_ids: List[int] = []
 
 
+class EntityLocation(ValidationErrorLocation):
+    """Location information for Entity-based validation errors"""
+
+    location_type: Literal["entity"] = "entity"
+    identifying_property_list: List[str]
+    identifying_property_values: List[Tuple[Union[int, float, str, None], ...]]
+
+
 # Example of another ValidationErrorLocation subclass
 class FileLocation(ValidationErrorLocation):
     location_type: Literal["file"] = "file"
@@ -31,7 +39,7 @@ class FileLocation(ValidationErrorLocation):
 
 # The discriminated union definition
 LocationUnion = Annotated[
-    Union[DataFrameLocation, FileLocation],
+    Union[DataFrameLocation, FileLocation, EntityLocation],
     Field(discriminator="location_type"),
 ]
 

--- a/tests/end_to_end/validation/input/test_01/config/validation_test_01_config.yaml
+++ b/tests/end_to_end/validation/input/test_01/config/validation_test_01_config.yaml
@@ -41,7 +41,7 @@ observable_properties:
   unique_name: id_sample
   name: id_sample
   ui_label: id_sample
-  value_type: decimal
+  value_type: integer
   categorical: false
   multivalued: false
   default_unit: UNITLESS
@@ -55,7 +55,7 @@ observable_properties:
   name: samplingyear
   description: year of sample collection
   ui_label: samplingyear
-  value_type: decimal
+  value_type: integer
   categorical: false
   multivalued: false
   default_unit: UNITLESS
@@ -108,7 +108,7 @@ observable_properties:
   name: samplingday
   description: day of sample collection (1 is the first day of the month)
   ui_label: samplingday
-  value_type: decimal
+  value_type: integer
   categorical: false
   multivalued: false
   default_unit: UNITLESS
@@ -122,7 +122,7 @@ observable_properties:
   name: samplinghour
   description: Hour of sampling
   ui_label: samplinghour
-  value_type: decimal
+  value_type: integer
   categorical: false
   multivalued: false
   default_unit: UNITLESS
@@ -136,7 +136,7 @@ observable_properties:
   name: samplingminutes
   description: Minutes of sampling
   ui_label: samplingminutes
-  value_type: decimal
+  value_type: integer
   categorical: false
   multivalued: false
   default_unit: UNITLESS

--- a/tests/end_to_end/validation/test_dataframe_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_validation.py
@@ -7,7 +7,7 @@ from tests.test_utils.dirutils import get_absolute_path
 from typing import cast
 
 from pypeh import Session
-from pypeh.core.models.validation_errors import ValidationError, ValidationErrorReport
+from pypeh.core.models.validation_errors import ValidationError, ValidationErrorReport, EntityLocation
 from pypeh.core.models.settings import LocalFileConfig
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,13 @@ class TestSessionDefaultLocalFile:
         assert isinstance(report_to_check, ValidationErrorReport)
         assert report_to_check.total_errors == 1
         assert report_to_check.groups[-1].errors[-1].type == "check_categorical"
+        assert len(report_to_check.groups[-1].errors[-1].locations) == 1
+        assert isinstance(report_to_check.groups[-1].errors[-1].locations[-1], EntityLocation)
+        assert len(report_to_check.groups[-1].errors[-1].locations[-1].identifying_property_values) == 1
+        assert isinstance(report_to_check.groups[-1].errors[-1].locations[-1].identifying_property_values[0], tuple)
+        assert len(report_to_check.groups[-1].errors[-1].locations[-1].identifying_property_values[0]) == 1
+        assert isinstance(report_to_check.groups[-1].errors[-1].locations[-1].identifying_property_values[0][0], int)
+        assert report_to_check.groups[-1].errors[-1].locations[-1].identifying_property_values[0][0] == 31
 
 
 @pytest.mark.end_to_end

--- a/uv.lock
+++ b/uv.lock
@@ -488,8 +488,8 @@ wheels = [
 
 [[package]]
 name = "dataguard"
-version = "0.4.2"
-source = { git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.2#fbcc10ed90eaa2c8f81998cec2a6a4f045e997a1" }
+version = "0.4.3"
+source = { git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.3#27c71e9ac221c3e08cb0b8c3920e453fa6356eb7" }
 dependencies = [
     { name = "pandera", extra = ["polars"] },
     { name = "polars" },
@@ -1613,7 +1613,7 @@ test-s3 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dataguard", marker = "extra == 'dataframe-adapter'", git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.2" },
+    { name = "dataguard", marker = "extra == 'dataframe-adapter'", git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.3" },
     { name = "fastexcel", marker = "extra == 'dataframe-adapter'" },
     { name = "fastexcel", marker = "extra == 'polars-adapter'" },
     { name = "fsspec" },
@@ -1641,7 +1641,7 @@ dev = [
 ]
 test-core = [{ name = "pytest", specifier = ">=8.2.0,<9" }]
 test-dataframe = [
-    { name = "dataguard", git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.2" },
+    { name = "dataguard", git = "https://github.com/eu-parc/dataguard.git?tag=v0.4.3" },
     { name = "fastexcel" },
     { name = "polars" },
     { name = "pyarrow" },


### PR DESCRIPTION
Sanity check to verify if this fulfills the expectations:
- location of the code in the outbound interface
- conditionally changing the location type under the hood without user involvement
- EntityLocation class
- not appended, but replaced the DataFrameLocation with an EntityLocation 

example of an error with an EntityLocation:
```
groups=[
  ValidationErrorGroup(
    group_id='64dc7d16-a09b-494f-84d2-4236f38d25df',
    group_type='pandera',
    name='peh:VALIDATION_TEST_SAMPLE_METADATA',
    metadata={},
    errors=[
      ValidationError(
        message="Column 'samplingmonth' failed validator number 0: <Check error: The column under validation is in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']> failure case examples: [{'samplingmonth': '15'}]",
        type='check_categorical',
        level=<ValidationErrorLevel.ERROR: 3>,
        locations=[
          EntityLocation(
            location_type='entity',
            identifying_property='id_sample',
            identifying_property_values=[31.0])],
        context=None,
        check_name='check_categorical',
        traceback=None, source=None)])]
```