### PR TITLE
walk entity from cache

### DIFF
--- a/tests/core/cache/test_cache.py
+++ b/tests/core/cache/test_cache.py
@@ -45,3 +45,15 @@ class TestCache:
         }
         cache_view = CacheContainerView(container, container_subset)
         assert len(list(cache_view.get_all())) == 3
+
+    def test_cache_nested(self, container):
+        ret = container.walk_entity(
+            entity_id="OBSERVATION_ADULTS_BLOODSERUM_LAB",
+            nested_entity_path=["observation_design", "required_observable_property_id_list"],
+            entity_type="Observation",
+        )
+        count = 0
+        for item in ret:
+            assert isinstance(item, ObservableProperty)
+            count += 1
+        assert count == 7


### PR DESCRIPTION
This might simplify extracting ObservableProperties related to a single Observation. This idea can be optimized if we add modifications to the underlying datastructure. But for now this might simplify building the dependency graph.