### PR TITLE
Refactor validation dto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ core = []
 rocrate-adapter = ["rocrate"]
 dataframe-adapter = [
     "dataguard",
-    "pandera>=0.27.0",
+	"pandera>=0.27.0",
     "polars",
     "pyarrow",
     "fastexcel",

--- a/src/pypeh/adapters/outbound/dataops/dataframe_adapter.py
+++ b/src/pypeh/adapters/outbound/dataops/dataframe_adapter.py
@@ -4,7 +4,11 @@ import logging
 import polars as pl
 from typing import TYPE_CHECKING
 
+from polars.datatypes import DataType
+from enum import Enum
+
 from pypeh.core.interfaces.outbound.dataops import OutDataOpsInterface
+from pypeh.core.models.constants import ObservablePropertyValueType
 
 if TYPE_CHECKING:
     from typing import Any
@@ -18,7 +22,9 @@ class DataFrameAdapter(OutDataOpsInterface[pl.DataFrame]):
     def get_element_labels(self, data: pl.DataFrame) -> list[str]:
         return data.columns
 
-    def get_element_values(self, data: pl.DataFrame, element_label: str) -> set[str]:
+    def get_element_values(self, data: pl.DataFrame, element_label: str, as_list=False) -> list[str] | set[str]:
+        if as_list:
+            return data.get_column(element_label).to_list()
         return set(data.get_column(element_label))
 
     def subset(
@@ -38,3 +44,25 @@ class DataFrameAdapter(OutDataOpsInterface[pl.DataFrame]):
 
     def relabel(self, data: pl.DataFrame, element_mapping: dict[str, str]) -> pl.DataFrame:
         return data.rename(element_mapping)
+
+    def type_mapper(self, peh_value_type: str | ObservablePropertyValueType) -> type[DataType]:
+        if isinstance(peh_value_type, Enum):
+            peh_value_type = peh_value_type.value
+
+        match peh_value_type:
+            case "string":
+                return pl.String
+            case "boolean":
+                return pl.Boolean
+            case "date":
+                return pl.Date
+            case "datetime":
+                return pl.Datetime
+            case "decimal":
+                return pl.Float64
+            case "integer":
+                return pl.Int64
+            case "float":
+                return pl.Float64
+            case _:
+                return pl.String

--- a/src/pypeh/adapters/outbound/enrichment/dataframe_adapter.py
+++ b/src/pypeh/adapters/outbound/enrichment/dataframe_adapter.py
@@ -4,14 +4,10 @@ import logging
 
 import polars as pl
 
-from polars.datatypes import DataType
-from enum import Enum
-
 from pypeh.adapters.outbound.dataops.dataframe_adapter import DataFrameAdapter
 from pypeh.core.interfaces.outbound.dataops import (
     DataEnrichmentInterface,
 )
-from pypeh.core.models.constants import ObservablePropertyValueType
 from pypeh.core.models.graph import Node
 from pypeh.core.models.internal_data_layout import JoinSpec
 
@@ -66,25 +62,3 @@ class DataFrameEnrichmentAdapter(DataFrameAdapter, DataEnrichmentInterface[pl.Da
         for dataset in datasets.values():
             if isinstance(dataset, pl.LazyFrame):
                 dataset = dataset.collect()
-
-    def type_mapper(self, peh_value_type: str | ObservablePropertyValueType) -> type[DataType]:
-        if isinstance(peh_value_type, Enum):
-            peh_value_type = peh_value_type.value
-
-        match peh_value_type:
-            case "string":
-                return pl.String
-            case "boolean":
-                return pl.Boolean
-            case "date":
-                return pl.Date
-            case "datetime":
-                return pl.Datetime
-            case "decimal":
-                return pl.Float64
-            case "integer":
-                return pl.Int64
-            case "float":
-                return pl.Float64
-            case _:
-                return pl.String

--- a/src/pypeh/adapters/outbound/validation/pandera_adapter/validation_adapter.py
+++ b/src/pypeh/adapters/outbound/validation/pandera_adapter/validation_adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import polars as pl
 
-from collections import defaultdict
+
 from contextlib import contextmanager
 from dataguard import Validator, ErrorCollector
 from peh_model.peh import DataLayout
@@ -21,7 +21,6 @@ from pypeh.core.interfaces.outbound.dataops import (
     ValidationInterface,
     DataImportInterface,
 )
-from pypeh.core.models.internal_data_layout import Dataset
 from pypeh.core.models.validation_errors import ValidationErrorReport, EntityLocation
 from pypeh.core.models.validation_dto import ValidationConfig
 from pypeh.core.session.connections import ConnectionManager
@@ -90,47 +89,25 @@ class DataFrameValidationAdapter(DataFrameAdapter, ValidationInterface[DataFrame
 
         return report
 
-    def _join_dataset(
+    def _join_data(
         self,
-        identifying_observable_property_ids: list[str],
-        dataset: Dataset[DataFrame],
-        dependent_data: dict[str, Dataset[DataFrame]],
-        dependent_observable_property_ids: set[str],
-        observable_property_id_to_dataset_label_dict: dict[str, str],
+        data: DataFrame,
+        other_data: list[DataFrame],
+        join_on: list[str],
+        subset_fields_other: list[list[str]],
     ) -> DataFrame:
-        joined_data = dataset.data
-        assert isinstance(
-            joined_data, DataFrame
-        ), "joined_data in `DataFrameAdapter._join_dataset` should be a DataFrame"
-        if dataset.label not in dependent_data:
-            dependent_data[dataset.label] = dataset
+        assert len(other_data) == len(subset_fields_other)
+        this = data
+        for other, subset_fields in zip(other_data, subset_fields_other):
+            selected = other.select(subset_fields)
 
-        dataset_label_to_observable_property_id_list = defaultdict(list)
-        for observable_property_id in dependent_observable_property_ids:
-            dataset_label = observable_property_id_to_dataset_label_dict.get(observable_property_id, None)
-            assert dataset_label is not None
-            dataset_label_to_observable_property_id_list[dataset_label].append(observable_property_id)
+            this = this.join(
+                selected,
+                on=join_on,
+                how="left",
+            )
 
-        for dataset_label, observable_property_id_list in dataset_label_to_observable_property_id_list.items():
-            dependent_dataset = dependent_data.get(dataset_label, None)
-            if dependent_dataset is not None:
-                dependent_element_labels = []
-                for dependent_obs_prop in observable_property_id_list:
-                    schema_element = dependent_dataset.get_schema_element_by_observable_property_id(dependent_obs_prop)
-                    assert schema_element is not None
-                    dependent_element_labels.append(schema_element.label)
-
-                other = dependent_dataset.data
-                assert isinstance(other, DataFrame), "other in `DataFrameAdapter._join_dataset` should be a DataFrame"
-                # JOIN ONLY WORKS WITH IF TWO FRAMES HAVE THE SAME IDENTIFYING_OBSERVABLE_PROPERTIES
-                joined_data = joined_data.join(
-                    other.select([*identifying_observable_property_ids, *dependent_element_labels]),
-                    on=identifying_observable_property_ids,
-                    how="left",
-                )
-            else:
-                raise ValueError(f"Did not find data section with label {dependent_dataset}")
-        return joined_data
+        return this
 
     def summarize(self, data: Mapping, config: Mapping):
         pass

--- a/src/pypeh/core/interfaces/outbound/dataops.py
+++ b/src/pypeh/core/interfaces/outbound/dataops.py
@@ -12,22 +12,20 @@ import importlib
 import logging
 
 from abc import abstractmethod
-from peh_model.peh import (
-    DataLayout,
-    DataLayoutSection,
-    EntityList,
-)
+from collections import defaultdict
+from peh_model import peh
 from typing import TYPE_CHECKING, Generic, cast, List
 
 from pypeh.core.cache.containers import CacheContainerView
-from pypeh.core.models.internal_data_layout import Dataset, DatasetSeries
+from pypeh.core.models.constants import ObservablePropertyValueType
+from pypeh.core.models.internal_data_layout import Dataset, DatasetSchemaElement, DatasetSeries
 from pypeh.core.models.typing import T_DataType
 from pypeh.core.models.settings import FileSystemSettings
 from pypeh.core.models import validation_dto
 from pypeh.core.session.connections import ConnectionManager
 
 if TYPE_CHECKING:
-    from typing import Sequence, Mapping, Any
+    from typing import Sequence, Any
     from pypeh.core.models.validation_errors import ValidationErrorReport
 
 logger = logging.getLogger(__name__)
@@ -44,13 +42,12 @@ class OutDataOpsInterface(Generic[T_DataType]):
     """
 
     @abstractmethod
-    def _join_dataset(
+    def _join_data(
         self,
-        identifying_observable_property_ids: list[str],
-        dataset: Dataset[T_DataType],
-        dependent_data: Mapping[str, Dataset[T_DataType]],
-        dependent_observable_property_ids: set[str],
-        observable_property_id_to_dataset_label_dict: dict[str, str],
+        data: T_DataType,
+        other_data: list[T_DataType],
+        join_on: list[str],
+        subset_fields_other: list[list[str]],
     ) -> T_DataType:
         raise NotImplementedError
 
@@ -63,7 +60,7 @@ class OutDataOpsInterface(Generic[T_DataType]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_element_values(self, data: T_DataType, element_label: str) -> set[str]:
+    def get_element_values(self, data: T_DataType, element_label: str, as_list=True) -> set[str] | list[str]:
         raise NotImplementedError
 
     @abstractmethod
@@ -79,6 +76,10 @@ class OutDataOpsInterface(Generic[T_DataType]):
 
     @abstractmethod
     def collect(self, datasets: dict):
+        raise NotImplementedError
+
+    @abstractmethod
+    def type_mapper(self, peh_value_type: str | ObservablePropertyValueType):
         raise NotImplementedError
 
 
@@ -101,6 +102,196 @@ class ValidationInterface(OutDataOpsInterface, Generic[T_DataType]):
             raise e
         return adapter_class
 
+    def build_column_validation(
+        self,
+        dataset_schema_element: DatasetSchemaElement,
+        type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
+        cache_view: CacheContainerView,
+        dataset_label: str | None = None,
+    ) -> validation_dto.ColumnValidation:
+        validations = []
+        observable_property_id = dataset_schema_element.observable_property_id
+        observable_property = cache_view.get(observable_property_id, "ObservableProperty")
+        assert isinstance(
+            observable_property, peh.ObservableProperty
+        ), f"ObservableProperty with id {observable_property_id} not found"
+        required = observable_property.default_required
+        nullable = not required
+
+        if validation_designs := getattr(observable_property, "validation_designs", None):
+            validations.extend(
+                [
+                    validation_dto.ValidationDesign.from_peh(
+                        vd, type_annotations=type_annotations, dataset_label=dataset_label
+                    )
+                    for vd in validation_designs
+                ]
+            )
+        if value_metadata := getattr(observable_property, "value_metadata", None):
+            validations.extend(
+                validation_dto.ValidationDesign.list_from_metadata(
+                    value_metadata, type_annotations=type_annotations, dataset_label=dataset_label
+                )
+            )
+        if getattr(observable_property, "categorical", None):
+            value_options = getattr(observable_property, "value_options", None)
+            assert (
+                value_options is not None
+            ), f"ObservableProperty {observable_property} lacks `value_options` for categorical type"
+            assert dataset_schema_element.data_type == ObservablePropertyValueType.STRING
+            validation_arg_values: list[str] = [str(vo.key) for vo in value_options]
+            expr = validation_dto.ValidationExpression(
+                command="is_in",
+                arg_values=validation_arg_values,
+                arg_columns=None,
+                subject=None,
+            )
+            validation = validation_dto.ValidationDesign(
+                name="check_categorical",
+                error_level=validation_dto.ValidationErrorLevel.ERROR,
+                expression=expr,
+            )
+            validations.append(validation)
+
+        assert dataset_schema_element.data_type.value != "decimal"
+        # transformation using context_magic
+        assert isinstance(required, bool)
+        return validation_dto.ColumnValidation(
+            unique_name=dataset_schema_element.label,
+            data_type=dataset_schema_element.data_type.value,
+            required=required,
+            nullable=nullable,
+            validations=validations,
+        )
+
+    def collect_column_validations(
+        self,
+        dataset: Dataset,
+        type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
+        cache_view: CacheContainerView,
+    ) -> list[validation_dto.ColumnValidation]:
+        column_validations: list[validation_dto.ColumnValidation] = []
+        non_empty_columns = dataset.non_empty
+        assert non_empty_columns is not None
+        for non_empty_column in non_empty_columns:
+            dataset_schema_element = dataset.get_schema_element_by_label(non_empty_column)
+            assert dataset_schema_element is not None
+            column_validation = self.build_column_validation(
+                dataset_schema_element=dataset_schema_element,
+                cache_view=cache_view,
+                type_annotations=type_annotations,
+            )
+            column_validations.append(column_validation)
+
+        return column_validations
+
+    def build_dataset_level_validations(
+        self,
+        dataset: Dataset,
+        dataset_series: DatasetSeries | None = None,
+        cache_view: CacheContainerView | None = None,
+    ) -> list[validation_dto.ValidationDesign] | None:
+        dataset_level_validations: list[validation_dto.ValidationDesign] = []
+        if cache_view is None:
+            raise NotImplementedError
+
+        if dataset_series is not None:
+            type_annotations = dataset_series.get_type_annotations()
+        else:
+            type_annotations = {dataset.label: dataset.get_type_annotations()}
+        layout_section_id = dataset.described_by
+        if layout_section_id is None:
+            return None
+        assert isinstance(layout_section_id, str)
+        layout_section = cache_view.get(layout_section_id, "DataLayoutSection")
+        assert layout_section is not None
+        assert isinstance(layout_section, peh.DataLayoutSection)
+        if layout_section.validation_designs:
+            for vd in layout_section.validation_designs:
+                assert isinstance(vd, peh.ValidationDesign)
+                dataset_validation = validation_dto.ValidationDesign.from_peh(vd, type_annotations)
+                # For an expression that relies on a field reference spec for its arguments, set the validation arguments
+                # as the actual values from the dataset (e.g. for an "is_in" check on a foreign key relation)
+                validation_expression = vd.validation_expression
+                assert isinstance(validation_expression, peh.ValidationExpression)
+                if validation_expression.validation_arg_contextual_field_references:
+                    arg_values = validation_expression.validation_arg_values
+                    assert isinstance(arg_values, list)
+                    for ref in validation_expression.validation_arg_contextual_field_references:
+                        assert isinstance(ref, peh.ContextualFieldReference)
+                        dataset_label = ref.dataset_label
+                        assert dataset_label is not None
+                        field_label = ref.field_label
+                        assert field_label is not None
+                        if dataset_series is None:
+                            assert dataset_label == dataset.label
+                            dependent_dataset = dataset
+                        else:
+                            dependent_dataset = dataset_series[dataset_label]
+                        assert dependent_dataset is not None
+                        # fix this at the Interface level
+                        column_arg_values = self.get_element_values(dependent_dataset.data, field_label, as_list=True)
+                        arg_values.extend(column_arg_values)
+                    dataset_validation.expression.arg_values = arg_values
+                    dataset_validation.expression.arg_columns = None
+                    dataset_level_validations.append(dataset_validation)
+
+        return dataset_level_validations
+
+    @classmethod
+    def merge_contextual_field_reference_dependencies(
+        cls, column_validations: list[validation_dto.ColumnValidation]
+    ) -> dict[str, set[str]]:
+        dependent_contextual_field_references = defaultdict(set)
+        for column_validation in column_validations:
+            if column_validation.validations is not None:
+                for validation_design in column_validation.validations:
+                    dependency_dict = validation_design.dependent_contextual_field_references
+                    if dependency_dict is not None:
+                        for ds, fields in dependency_dict.items():
+                            dependent_contextual_field_references[ds].update(fields)
+
+        return dependent_contextual_field_references
+
+    def build_validation_config(
+        self,
+        dataset: Dataset,
+        dataset_series: DatasetSeries | None = None,
+        cache_view: CacheContainerView | None = None,
+    ) -> validation_dto.ValidationConfig:
+        column_validations = []
+        dataset_validations = []
+        if cache_view is None:
+            raise NotImplementedError("The absence of a CacheView is currently not supported")
+
+        identifying_column_names = dataset.get_primary_keys()
+        if identifying_column_names is not None:
+            identifying_column_names = list(identifying_column_names)
+
+        if dataset_series is None:
+            type_annotations = {dataset.label: dataset.get_type_annotations()}
+        else:
+            type_annotations = dataset_series.get_type_annotations()
+        column_validations = self.collect_column_validations(
+            dataset=dataset,
+            type_annotations=type_annotations,
+            cache_view=cache_view,
+        )
+        dependent_contextual_field_references = self.merge_contextual_field_reference_dependencies(column_validations)
+        dataset_validations = self.build_dataset_level_validations(
+            dataset=dataset,
+            dataset_series=dataset_series,
+            cache_view=cache_view,
+        )
+
+        return validation_dto.ValidationConfig(
+            name=dataset.label,
+            columns=column_validations,
+            identifying_column_names=identifying_column_names,
+            validations=dataset_validations,
+            dependent_contextual_field_references=dependent_contextual_field_references,
+        )
+
     def validate(
         self,
         dataset: Dataset[T_DataType],
@@ -108,79 +299,50 @@ class ValidationInterface(OutDataOpsInterface, Generic[T_DataType]):
         cache_view: CacheContainerView | None = None,
     ) -> ValidationErrorReport:
         assert dataset.data is not None
-        to_validate: T_DataType = dataset.data
-        type_annotations = dataset.get_type_annotations()
-        # Get Dataset level validations if they exist for the describing DataLayoutSection
-        dataset_validations = []
+        assert cache_view is not None
+        to_validate = dataset.data
+        assert to_validate is not None
 
-        layout_section_id = dataset.described_by
-        if layout_section_id:
-            assert cache_view is not None
-            layout_section = cache_view.get(layout_section_id, "DataLayoutSection")
-            assert layout_section is not None
-            assert isinstance(layout_section, DataLayoutSection)
-            if layout_section.validation_designs:
-                for vd in layout_section.validation_designs:
-                    dataset_validation = validation_dto.ValidationDesign.from_layout(vd, type_annotations, cache_view)
-                    # For an expression that relies on a field reference spec for its arguments, set the validation arguments
-                    # as the actual values from the dataset (e.g. for an "is_in" check on a foreign key relation)
-                    if vd.validation_expression.validation_arg_contextual_field_references:
-                        arg_values = vd.validation_expression.validation_arg_values
-                        for ref in vd.validation_expression.validation_arg_contextual_field_references:
-                            arg_values.extend(
-                                dependent_dataset_series[ref.dataset_label].data.get_column(ref.field_label).to_list()
-                            )
-                        dataset_validation.expression.arg_values = arg_values
-                        dataset_validation.expression.arg_columns = None
-                    dataset_validations.append(dataset_validation)
-
-        validation_config = validation_dto.ValidationConfig.from_dataset(
+        validation_config = self.build_validation_config(
             dataset,
-            dataset_validations,
+            dependent_dataset_series,
             cache_view,
         )
-        join_required = False
         # check whether data requires join to perform validation (cross DataLayoutSection validation)
-        dependent_observable_property_ids = validation_config.dependent_observable_property_ids
-        if dependent_observable_property_ids is not None:
-            join_required = len(dependent_observable_property_ids) > 0
+        join_required = False
+        dependent_contextual_field_references = validation_config.dependent_contextual_field_references
+        if dependent_contextual_field_references is not None:
+            join_required = len(dependent_contextual_field_references) > 0
 
         if join_required:
             if dependent_dataset_series is None:
-                me = f"`dependent_data` is required to perform all validations. One or more of the following `ObservableProperty`s cannot be found in the current `DataLayoutSection`: {', '.join(dependent_observable_property_ids)}"
+                me = "`dependent_data` is required to perform all validations with `ValidationInterface`"
                 logger.error(me)
                 raise ValueError(me)
             else:
                 assert (
-                    dependent_observable_property_ids is not None
-                ), "dependent_observable_property_ids in `ValidationInterface.validate` should not be None"
+                    dependent_contextual_field_references is not None
+                ), "dependent_contextual_field_references in `ValidationInterface.validate` should not be None"
                 assert dependent_dataset_series is not None
-                # TEMP: looping over datasets should not be necessary when contextual_field_references are implemented
-                observable_property_id_to_dataset_label_dict = dict()
-                for observable_property_id in dependent_observable_property_ids:
-                    found = False
-                    for dataset_label in dependent_dataset_series:
-                        dependent_dataset = dependent_dataset_series[dataset_label]
-                        assert dependent_dataset is not None
-                        all_obs_props = set(dependent_dataset.get_observable_property_ids())
-                        if observable_property_id in all_obs_props:
-                            observable_property_id_to_dataset_label_dict[observable_property_id] = dataset_label
-                            found = True
-                            break
-                    assert found, f"Did not find {observable_property_id}"
+                identifying_field_labels = dataset.schema.primary_keys
+                assert identifying_field_labels is not None
+                all_other_data = []
+                subset_fields_other = []
 
-                identifying_obs_prop_id_list = dataset.schema.primary_keys
-                assert (
-                    identifying_obs_prop_id_list is not None
-                ), "identifying_obs_prop_id_list in `ValidationInterface.validate` should not be None"
-
-                to_validate = self._join_dataset(
-                    identifying_observable_property_ids=identifying_obs_prop_id_list,
-                    dataset=dataset,
-                    dependent_data=dependent_dataset_series.parts,
-                    dependent_observable_property_ids=dependent_observable_property_ids,
-                    observable_property_id_to_dataset_label_dict=observable_property_id_to_dataset_label_dict,
-                )
+                for dataset_label, dependent_field_labels in dependent_contextual_field_references.items():
+                    other_dataset = dependent_dataset_series[dataset_label]
+                    assert other_dataset is not None
+                    other_data = other_dataset.data
+                    assert other_data is not None
+                    all_other_data.append(other_data)
+                    field_subset = [*identifying_field_labels, *dependent_field_labels]
+                    subset_fields_other.append(field_subset)
+                    to_validate = self._join_data(
+                        data=to_validate,
+                        other_data=all_other_data,
+                        join_on=list(identifying_field_labels),
+                        subset_fields_other=subset_fields_other,
+                    )
 
         ret = self._validate(to_validate, validation_config)
 
@@ -234,19 +396,19 @@ class DataImportInterface(OutDataOpsInterface, Generic[T_DataType]):
         source: str,
         config: FileSystemSettings,
         **kwargs,
-    ) -> DataLayout | List[DataLayout]:
+    ) -> peh.DataLayout | List[peh.DataLayout]:
         provider = ConnectionManager._create_adapter(config)
         layout = provider.load(source)
-        if isinstance(layout, EntityList):
+        if isinstance(layout, peh.EntityList):
             layout = layout.layouts
         if isinstance(layout, list):
-            if not all(isinstance(item, DataLayout) for item in layout):
+            if not all(isinstance(item, peh.DataLayout) for item in layout):
                 me = "Imported layouts should all be DataLayout instances"
                 logger.error(me)
                 raise TypeError(me)
-            return cast(List[DataLayout], layout)
+            return cast(List[peh.DataLayout], layout)
 
-        elif isinstance(layout, DataLayout):
+        elif isinstance(layout, peh.DataLayout):
             return layout
 
         else:

--- a/src/pypeh/core/models/constants.py
+++ b/src/pypeh/core/models/constants.py
@@ -52,16 +52,34 @@ class ValidationErrorLevel(Enum):
     FATAL = auto()
 
 
-class ObservablePropertyValueType(str, Enum):
-    """
-    Enum representing the possible value types for observable properties.
-    """
+_ALIASES: dict[str, str] = {
+    "decimal": "float",
+}
 
+
+class ObservablePropertyValueType(str, Enum):
     STRING = "string"
     INTEGER = "integer"
     BOOLEAN = "boolean"
     FLOAT = "float"
-    CATEGORICAL = "categorical"
     DECIMAL = "decimal"
+    CATEGORICAL = "categorical"
     DATE = "date"
     DATETIME = "datetime"
+
+    def __new__(cls, value):
+        # remap before Enum processes it
+        normalized = value.lower()
+        if normalized in _ALIASES:
+            value = _ALIASES[normalized]
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        return obj
+
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            normalized = value.lower()
+            if normalized in _ALIASES:
+                return cls(_ALIASES[normalized])
+        return super()._missing_(value)

--- a/src/pypeh/core/models/internal_data_layout.py
+++ b/src/pypeh/core/models/internal_data_layout.py
@@ -9,10 +9,11 @@ from dataclasses import dataclass, field
 from peh_model import peh
 from typing import TYPE_CHECKING, Generic, Sequence
 
-from pypeh.core.cache.containers import CacheContainerView
+from pypeh.core.cache.containers import CacheContainer, CacheContainerView
 from pypeh.core.models.proxy import TypedLazyProxy
 from pypeh.core.models.typing import T_DataType
 from pypeh.core.models.constants import ObservablePropertyValueType
+
 
 if TYPE_CHECKING:
     from typing import Any
@@ -120,6 +121,89 @@ class DatasetSchema:
     def get_observable_property_ids(self) -> list[str]:
         return [element.observable_property_id for element in self.elements.values()]
 
+    # TODO: move method, this is probably not the right location
+    def apply_context_to_expression(
+        self,
+        expression: peh.ValidationExpression,
+        context: dict[str, dict[str, str]],
+        this_dataset: str,  # temporary fix
+    ):
+        expression_stack = [expression]
+        while expression_stack:
+            expression = expression_stack.pop()
+            assert isinstance(expression, peh.ValidationExpression)
+            conditional_expression = expression.validation_condition_expression
+            if conditional_expression is not None:
+                assert isinstance(conditional_expression, peh.ValidationExpression)
+                expression_stack.append(conditional_expression)
+            arg_expressions = expression.validation_arg_expressions
+            if arg_expressions is not None:
+                for arg_expression in arg_expressions:
+                    assert isinstance(arg_expression, peh.ValidationExpression)
+                    expression_stack.append(arg_expression)
+
+            # apply context
+            arg_field_references = expression.validation_arg_contextual_field_references
+            if arg_field_references is not None:
+                for arg_ref in arg_field_references:
+                    assert isinstance(arg_ref, peh.ContextualFieldReference)
+                    field_label = arg_ref.field_label
+                    if field_label in context:
+                        retrieved_context = context[field_label]
+                        if len(retrieved_context) == 1:
+                            new_dataset_label = next(iter(retrieved_context))
+                        else:
+                            new_dataset_label = this_dataset
+                        new_field_label = retrieved_context[new_dataset_label]
+                        arg_ref.dataset_label = new_dataset_label
+                        arg_ref.field_label = new_field_label
+
+            subject_field_references = expression.validation_subject_contextual_field_references
+            if subject_field_references is not None:
+                for subject_field_ref in subject_field_references:
+                    assert isinstance(subject_field_ref, peh.ContextualFieldReference)
+                    field_label = subject_field_ref.field_label
+                    if field_label in context:
+                        retrieved_context = context[field_label]
+                        if len(retrieved_context) == 1:
+                            new_dataset_label = next(iter(retrieved_context))
+                        else:
+                            new_dataset_label = this_dataset
+                        new_field_label = retrieved_context[new_dataset_label]
+                        subject_field_ref.dataset_label = new_dataset_label
+                        subject_field_ref.field_label = new_field_label
+
+    def apply_context(
+        self,
+        context: dict[str, dict[str, str]],
+        cache: CacheContainer,
+        this_dataset: str,  # temporary fix
+    ):
+        """
+        ObservableProperties require context for:
+        - CalculationDesigns
+        - ValidationDesigns
+        """
+        for schema_element in self.elements.values():
+            observable_property_id = schema_element.observable_property_id
+            observable_property = cache.get(observable_property_id, "ObservableProperty")
+            assert isinstance(observable_property, peh.ObservableProperty)
+            validation_designs = observable_property.validation_designs
+            if validation_designs is not None:
+                for validation_design in validation_designs:
+                    assert isinstance(validation_design, peh.ValidationDesign)
+                    expression = validation_design.validation_expression
+                    assert isinstance(expression, peh.ValidationExpression)
+                    self.apply_context_to_expression(expression, context, this_dataset=this_dataset)
+
+            # CALCULATION DESIGN EXCLUDED FOR NOW
+            # calculation_designs = observable_property.calculation_designs
+            # if calculation_designs is not None:
+            #    for calculation_design in calculation_designs:
+            #        pass
+
+    #### RESTRUCTURE DATASETSCHEMA ####
+
     def subset(self, element_group: Sequence[str]) -> DatasetSchema:
         elements = {}
         foreign_keys = {}
@@ -201,6 +285,8 @@ class DatasetSchema:
     def __len__(self):
         return len(self.elements)
 
+    #### CONSTRUCT DATASETSCHEMA ####
+
     @classmethod
     def from_peh_data_layout_elements(
         cls, data_layout_elements: list[peh.DataLayoutElement], cache_view: CacheContainerView
@@ -245,6 +331,8 @@ class DatasetSchema:
             foreign_keys=processed_foreign_keys,
             primary_keys=processed_primary_keys,
         )
+
+    #### EXTRACT INFO FROM SCHEMA ####
 
     def detect_join(
         self,
@@ -307,6 +395,10 @@ class DatasetSchema:
 
 @dataclass(kw_only=True)
 class Resource:
+    """
+    Parent class for Dataset and DatasetSeries
+    """
+
     label: str
     identifier: str = field(default_factory=lambda: str(uuid.uuid4()))
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -342,6 +434,8 @@ class Dataset(Resource, Generic[T_DataType]):
     def get_type_annotations(self) -> dict[str, ObservablePropertyValueType]:
         return self.schema.get_type_annotations()
 
+    #### CONSTRUCT DATASET ####
+
     @classmethod
     def from_peh_datalayout_section(
         cls,
@@ -371,6 +465,8 @@ class Dataset(Resource, Generic[T_DataType]):
 
         return ret
 
+    #### EXTRACT INFO FROM DATASET ####
+
     @property
     def non_empty(self):
         return self.metadata.get("non_empty_dataset_elements", None)
@@ -386,6 +482,13 @@ class Dataset(Resource, Generic[T_DataType]):
 
     def get_primary_keys(self) -> set[str] | None:
         return self.schema.primary_keys
+
+    def resolve_join(self, other: Dataset) -> list[JoinSpec] | None:
+        schema = self.schema
+        assert schema is not None
+        return schema.detect_join(dataset_label=self.label, other_schema=other.schema, other_dataset_label=other.label)
+
+    #### RESTRUCTURE DATASET ####
 
     def subset(
         self,
@@ -431,11 +534,6 @@ class Dataset(Resource, Generic[T_DataType]):
 
         return True
 
-    def resolve_join(self, other: Dataset) -> list[JoinSpec] | None:
-        schema = self.schema
-        assert schema is not None
-        return schema.detect_join(dataset_label=self.label, other_schema=other.schema, other_dataset_label=other.label)
-
 
 @dataclass(kw_only=True)
 class DatasetSeries(Resource, Generic[T_DataType]):
@@ -446,8 +544,19 @@ class DatasetSeries(Resource, Generic[T_DataType]):
         "context": DCAT_CONTEXT,
     }
 
+    #### CONSTRUCT DATASETSERIES ####
+    def apply_context(self, cache: CacheContainer):
+        # THIS METHOD MODIFIES THE CACHE !!!
+        context = self.get_contextual_field_reference_index()
+        for dataset_label in self:
+            dataset = self.get(dataset_label)
+            assert dataset is not None
+            dataset.schema.apply_context(context, cache, this_dataset=self.label)
+
     @classmethod
-    def from_peh_datalayout(cls, data_layout: peh.DataLayout, cache_view: CacheContainerView) -> DatasetSeries:
+    def from_peh_datalayout(
+        cls, data_layout: peh.DataLayout, cache_view: CacheContainerView, apply_context: bool = True
+    ) -> DatasetSeries:
         parts = dict()
         label = data_layout.ui_label
         assert label is not None
@@ -466,13 +575,8 @@ class DatasetSeries(Resource, Generic[T_DataType]):
             dataset.part_of = ret
         _ = ret.add_metadata("described_by", data_layout.id)
 
-        return ret
-
-    def get_type_annotations(self) -> dict[str, dict[str, ObservablePropertyValueType]]:
-        ret: dict[str, dict[str, ObservablePropertyValueType]] = dict()
-        for dataset in self.parts.values():
-            label = dataset.label
-            ret[label] = dataset.get_type_annotations()
+        if apply_context:
+            ret.apply_context(cache=cache_view._container)
 
         return ret
 
@@ -490,6 +594,8 @@ class DatasetSeries(Resource, Generic[T_DataType]):
         dataset.metadata["non_empty_dataset_elements"] = non_empty_dataset_elements
 
         return True
+
+    #### RESTRUCTURE DATASETSERIES ####
 
     def subset_dataset(
         self,
@@ -611,6 +717,16 @@ class DatasetSeries(Resource, Generic[T_DataType]):
         for dataset_label in to_remove:
             self.parts.pop(dataset_label)
 
+    #### EXTRACT INFO FROM DATASETSERIES ####
+
+    def get_type_annotations(self) -> dict[str, dict[str, ObservablePropertyValueType]]:
+        ret: dict[str, dict[str, ObservablePropertyValueType]] = dict()
+        for dataset in self.parts.values():
+            label = dataset.label
+            ret[label] = dataset.get_type_annotations()
+
+        return ret
+
     def resolve_join(self, left_dataset_label: str, right_dataset_label: str) -> list[JoinSpec] | None:
         left = self.get(left_dataset_label)
         assert left is not None
@@ -638,6 +754,22 @@ class DatasetSeries(Resource, Generic[T_DataType]):
         # dataset_fields = adapter.get_element_labels(dataset[dataset_label])
 
         return ret
+
+    def get_contextual_field_reference_index(self) -> dict[str, dict[str, str]]:
+        """
+        ObservablePropertyId -> dataset_label, field_label
+        We currently assume that each observable_property only occurs once in the DatasetSeries
+        """
+        field_ref_dict = defaultdict(dict)
+        for dataset_label in self:
+            dataset = self.get(dataset_label)
+            assert dataset is not None
+            for observable_property_id, element_label in dataset.schema._elements_by_observable_property.items():
+                field_ref_dict[observable_property_id][dataset_label] = element_label
+
+        return field_ref_dict
+
+    #### CORE FUNCTIONALITY ####
 
     @property
     def data_import_config(self) -> str | None:

--- a/src/pypeh/core/models/typing.py
+++ b/src/pypeh/core/models/typing.py
@@ -37,7 +37,3 @@ IOLike = Union[
     TextIO,
     BinaryIO,
 ]
-
-
-class CategoricalString(str):
-    pass

--- a/src/pypeh/core/models/validation_dto.py
+++ b/src/pypeh/core/models/validation_dto.py
@@ -3,33 +3,21 @@ from __future__ import annotations
 import logging
 import uuid
 
-from datetime import datetime
-from decimal import Decimal, getcontext
+from collections import defaultdict
+from enum import Enum
 from pydantic import BaseModel, field_validator
 from typing import Generic, Any, Sequence, TYPE_CHECKING
 
-from pypeh.core.cache.containers import CacheContainerView
-from pypeh.core.models.internal_data_layout import DatasetSchema
-from pypeh.core.models.typing import CategoricalString, T_DataType
+from pypeh.core.models.typing import T_DataType
 from pypeh.core.models.constants import ObservablePropertyValueType, ValidationErrorLevel
 from peh_model import pydanticmodel_v2 as pehs
 from peh_model import peh
 
 
 if TYPE_CHECKING:
-    from pypeh.core.models.internal_data_layout import Dataset
+    pass
 
 logger = logging.getLogger(__name__)
-
-
-def get_max_decimal_value():
-    ctx = getcontext()
-    precision = ctx.prec
-    emax = ctx.Emax
-
-    max_digits = "9" * precision
-    max_value = Decimal(f"{max_digits}E{emax}")
-    return max_value
 
 
 def convert_peh_validation_error_level_to_validation_dto_error_level(peh_validation_error_level: str | None):
@@ -49,66 +37,12 @@ def convert_peh_validation_error_level_to_validation_dto_error_level(peh_validat
                 raise ValueError(f"Invalid Error level encountered: {peh_validation_error_level}")
 
 
-def convert_peh_value_type_to_validation_dto_datatype(peh_value_type: str):
-    # TODO: fix for "categorical" ?
-    # TODO: review & extend potential input values
-    # valid input values: "string", "boolean", "date", "datetime", "decimal", "integer", "float"
-    # valid return values: 'date', 'datetime', 'boolean', 'decimal', 'integer', 'varchar', 'float', or 'categorical'
-    if peh_value_type is None:
-        return None
-    else:
-        match peh_value_type:
-            case "decimal":
-                logger.info("Casting decimal to float")
-                return "float"
-            case "boolean" | "date" | "datetime" | "float" | "string" | "integer":
-                return peh_value_type
-            case _:
-                raise ValueError(f"Invalid data type encountered: {peh_value_type}")
-
-
-def infer_type(value: str) -> str:
-    val = value.strip()
-    # Boolean check
-    if val.lower() in ["true", "false"]:
-        return "boolean"
-    # Integer / Float check
-    try:
-        num = float(val)
-        # If it has no decimal part, it's an integer
-        if num.is_integer():
-            return "integer"
-        return "float"
-    except ValueError:
-        pass
-    # Date / Datetime check
-    date_formats = [
-        ("%Y-%m-%d", "date"),
-        ("%Y-%m-%d %H:%M:%S", "datetime"),
-        ("%Y-%m-%dT%H:%M:%S", "datetime"),  # ISO-like
-        ("%Y-%m-%d %H:%M:%S%z", "datetime"),
-        ("%Y-%m-%dT%H:%M:%S%z", "datetime"),
-    ]
-    for fmt, t in date_formats:
-        try:
-            datetime.strptime(val, fmt)
-            return t
-        except ValueError:
-            continue
-
-    # Fallback
-    return "string"
-
-
-def cast_to_peh_value_type(value: str, peh_value_type: str | None) -> Any:
+def cast_to_peh_value_type(value: str, peh_value_type: ObservablePropertyValueType | str | None) -> Any:
     # valid input values: "string", "boolean", "date", "datetime", "decimal", "float", "integer"
+    if isinstance(peh_value_type, Enum):
+        peh_value_type = peh_value_type.value
     if not isinstance(value, str):
         return value
-    if isinstance(value, CategoricalString):
-        return str(value)
-
-    if peh_value_type is None:
-        peh_value_type = infer_type(value)
 
     match peh_value_type:
         case "string":
@@ -130,6 +64,20 @@ def cast_to_peh_value_type(value: str, peh_value_type: str | None) -> Any:
             return str(value)
 
 
+def merge_dependencies(
+    a: dict[str, set[str]] | None,
+    b: dict[str, set[str]] | None,
+) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = defaultdict(set)
+    if a:
+        for ds, fields in a.items():
+            result[ds].update(fields)
+    if b:
+        for ds, fields in b.items():
+            result[ds].update(fields)
+    return result
+
+
 class ValidationExpression(BaseModel):
     conditional_expression: ValidationExpression | None = None
     arg_expressions: list[ValidationExpression] | None = None
@@ -137,6 +85,7 @@ class ValidationExpression(BaseModel):
     arg_values: list[Any] | None = None
     arg_columns: list[str] | None = None
     subject: list[str] | None = None
+    dependent_contextual_field_references: dict[str, set[str]] | None = None
 
     @field_validator("command", mode="before")
     @classmethod
@@ -157,115 +106,83 @@ class ValidationExpression(BaseModel):
     def from_peh(
         cls,
         expression: peh.ValidationExpression | pehs.ValidationExpression,
-        cache_view: CacheContainerView | None = None,
+        type_annotations: dict[str, dict[str, ObservablePropertyValueType]] | None = None,
+        dataset_label: str | None = None,
     ) -> "ValidationExpression":
+        dependent_contextual_field_references = defaultdict(set)
         conditional_expression = getattr(expression, "validation_condition_expression")
         conditional_expression_instance = None
         if conditional_expression is not None:
             conditional_expression_instance = ValidationExpression.from_peh(
-                conditional_expression, cache_view=cache_view
+                conditional_expression,
+                type_annotations,
+                dataset_label=dataset_label,
             )
+            dependent_contextual_field_references = merge_dependencies(
+                dependent_contextual_field_references,
+                conditional_expression_instance.dependent_contextual_field_references,
+            )
+
         arg_expressions = getattr(expression, "validation_arg_expressions")
         arg_expression_instances = None
         if arg_expressions is not None:
-            arg_expression_instances = [
-                ValidationExpression.from_peh(nested_expr, cache_view=cache_view) for nested_expr in arg_expressions
-            ]
-        validation_command = getattr(expression, "validation_command", "conjunction")
-
-        subject_contextual_field_references = getattr(
-            expression, "validation_subject_contextual_field_references", None
-        )
-
-        # TODO: extract type from dataset schema
-        arg_type = None
-        observable_property_id_based_subject_contextual_field_references = []
-        if subject_contextual_field_references:
-            arg_types = set()
-
-            if cache_view is not None:
-                for contextual_field_reference in [
-                    cfr for cfr in subject_contextual_field_references if cfr is not None
-                ]:
-                    obs_prop_id = contextual_field_reference.field_label
-                    observable_property_id_based_subject_contextual_field_references.append(obs_prop_id)
-                    obs_prop = cache_view.get(obs_prop_id, "ObservableProperty")
-                    assert isinstance(
-                        obs_prop, peh.ObservableProperty
-                    ), f"Did not find the ObservableProperty associated with contextual field reference {obs_prop_id}"
-                    new_arg_type = getattr(obs_prop, "value_type", None)
-                    arg_types.add(new_arg_type)
-            if len(arg_types) != 1:
-                logger.error(
-                    f"More than one type corresponds to the ObservableProperties in validation_subject_contextual_field_references: {arg_types}"
+            arg_expression_instances = []
+            for nested_expr in arg_expressions:
+                new_arg_expression = ValidationExpression.from_peh(
+                    nested_expr, type_annotations, dataset_label=dataset_label
                 )
-                raise ValueError
-            arg_type = arg_types.pop()
-
-        arg_values = getattr(expression, "validation_arg_values", None)
-        if arg_values is not None:
-            assert isinstance(arg_values, Sequence)
-            try:
-                arg_values = [cast_to_peh_value_type(arg_value, arg_type) for arg_value in arg_values]
-            except Exception as e:
-                logger.error(f"Could not cast values in {arg_values} to {arg_type}: {e}")
-                raise
-
-        # TODO: review cross-dataset column reference approach (in arg_columns and subject) and column identifier to return
-        arg_columns = [fr.field_label for fr in getattr(expression, "validation_arg_contextual_field_references", None)]
-
-        return cls(
-            conditional_expression=conditional_expression_instance,
-            arg_expressions=arg_expression_instances,
-            command=validation_command,
-            arg_values=arg_values,
-            arg_columns=arg_columns,
-            subject=[fr.field_label for fr in subject_contextual_field_references],
-        )
-
-    @classmethod
-    def from_layout(
-        cls,
-        expression: peh.ValidationExpression | pehs.ValidationExpression,
-        type_annotations: dict[str, ObservablePropertyValueType],
-        cache_view: CacheContainerView | None = None,
-    ) -> "ValidationExpression":
-        conditional_expression = getattr(expression, "validation_condition_expression")
-        conditional_expression_instance = None
-        if conditional_expression is not None:
-            conditional_expression_instance = ValidationExpression.from_peh(
-                conditional_expression, cache_view=cache_view
-            )
-        arg_expressions = getattr(expression, "validation_arg_expressions")
-        arg_expression_instances = None
-        if arg_expressions is not None:
-            arg_expression_instances = [
-                ValidationExpression.from_peh(nested_expr, cache_view=cache_view) for nested_expr in arg_expressions
-            ]
+                arg_expression_instances.append(new_arg_expression)
+                dependent_contextual_field_references = merge_dependencies(
+                    dependent_contextual_field_references, new_arg_expression.dependent_contextual_field_references
+                )
         validation_command = getattr(expression, "validation_command", "conjunction")
 
         subject_contextual_field_references = getattr(
             expression, "validation_subject_contextual_field_references", None
         )
-        subject = None
-        arg_type = None
+        subject_columns = None
+        data_type = None
         if subject_contextual_field_references is not None:
-            subject = [fr.field_label for fr in subject_contextual_field_references]
-            assert len(subject) == 1, "Can't deal with multiple validation_subject_contextual_field_references"
-            arg_type = type_annotations.get(subject[0], ObservablePropertyValueType.STRING)
-            arg_type = arg_type.value
+            subject_columns = []
+            data_types = set()
+            assert type_annotations is not None
+            for field_reference in subject_contextual_field_references:
+                ref_dataset_label = getattr(field_reference, "dataset_label", None)
+                assert ref_dataset_label is not None
+                if ref_dataset_label != dataset_label:
+                    dependent_contextual_field_references[ref_dataset_label].add(field_reference.field_label)
+                subject_columns.append(field_reference.field_label)
+                data_type = type_annotations.get(ref_dataset_label, {}).get(field_reference.field_label, None)
+                assert (
+                    data_type is not None
+                ), f"Did not find type_annotation for dataset with label {ref_dataset_label} and field_label {field_reference.field_label}"
+                data_types.add(data_type)
+            assert (
+                len(data_types) <= 1
+            ), f'Found the following datatypes for the subject_contextual_field_references: {", ".join(dt for dt in data_types)}'
+            data_type = next(iter(data_types), None)
+        if data_type is None:
+            data_type = ObservablePropertyValueType.STRING
 
         arg_values = getattr(expression, "validation_arg_values", None)
         if arg_values is not None:
             assert isinstance(arg_values, Sequence)
             try:
-                arg_values = [cast_to_peh_value_type(arg_value, arg_type) for arg_value in arg_values]
+                arg_values = [cast_to_peh_value_type(arg_value, data_type) for arg_value in arg_values]
             except Exception as e:
-                logger.error(f"Could not cast values in {arg_values} to {arg_type}: {e}")
+                logger.error(f"Could not cast values in {arg_values} to {data_type}: {e}")
                 raise
 
-        # TODO: review cross-dataset column reference approach (in arg_columns and subject) and column identifier to return
-        arg_columns = [fr.field_label for fr in getattr(expression, "validation_arg_contextual_field_references", None)]
+        arg_contextual_field_references = getattr(expression, "validation_arg_contextual_field_references", None)
+        arg_columns = None
+        if arg_contextual_field_references is not None:
+            arg_columns = []
+            for field_reference in arg_contextual_field_references:
+                ref_dataset_label = getattr(field_reference, "dataset_label", None)
+                assert ref_dataset_label is not None
+                if ref_dataset_label != dataset_label:
+                    dependent_contextual_field_references[ref_dataset_label].add(field_reference.field_label)
+                arg_columns.append(field_reference.field_label)
 
         return cls(
             conditional_expression=conditional_expression_instance,
@@ -273,7 +190,8 @@ class ValidationExpression(BaseModel):
             command=validation_command,
             arg_values=arg_values,
             arg_columns=arg_columns,
-            subject=subject,
+            subject=subject_columns,
+            dependent_contextual_field_references=dependent_contextual_field_references,
         )
 
 
@@ -281,55 +199,42 @@ class ValidationDesign(BaseModel):
     name: str
     error_level: ValidationErrorLevel
     expression: ValidationExpression
+    dependent_contextual_field_references: dict[str, set[str]] | None = None
 
     @classmethod
     def from_peh(
         cls,
         validation_design: peh.ValidationDesign | pehs.ValidationDesign,
-        cache_view: CacheContainerView | None = None,
+        type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
+        dataset_label: str | None = None,
     ) -> "ValidationDesign":
+        dependent_contextual_field_references = defaultdict(set)
         error_level = getattr(validation_design, "error_level", None)
         error_level = convert_peh_validation_error_level_to_validation_dto_error_level(error_level)
         expression = getattr(validation_design, "validation_expression", None)
         if expression is None:
             raise AttributeError
-        expression = ValidationExpression.from_peh(expression, cache_view=cache_view)
+        expression = ValidationExpression.from_peh(expression, type_annotations, dataset_label=dataset_label)
         name = getattr(validation_design, "validation_name", None)
         if name is None:
             name = str(uuid.uuid4())
-        return cls(
-            name=name,
-            error_level=error_level,
-            expression=expression,
-        )
 
-    @classmethod
-    def from_layout(
-        cls,
-        validation_design: peh.ValidationDesign | pehs.ValidationDesign,
-        type_annotations: dict[str, ObservablePropertyValueType],
-        cache_view: CacheContainerView | None = None,
-    ) -> "ValidationDesign":
-        error_level = getattr(validation_design, "error_level", None)
-        error_level = convert_peh_validation_error_level_to_validation_dto_error_level(error_level)
-        expression = getattr(validation_design, "validation_expression", None)
-        if expression is None:
-            raise AttributeError
-        expression = ValidationExpression.from_layout(expression, type_annotations, cache_view=cache_view)
-        name = getattr(validation_design, "validation_name", None)
-        if name is None:
-            name = str(uuid.uuid4())
+        dependent_contextual_field_references = merge_dependencies(
+            dependent_contextual_field_references, expression.dependent_contextual_field_references
+        )
         return cls(
             name=name,
             error_level=error_level,
             expression=expression,
+            dependent_contextual_field_references=dependent_contextual_field_references,
         )
 
     @classmethod
     def list_from_metadata(
         cls,
         metadata: list[Any],
-        cache_view: CacheContainerView | None = None,
+        type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
+        dataset_label: str | None = None,
     ) -> list["ValidationDesign"]:
         expression_list = []
         numeric_commands = set(
@@ -402,7 +307,8 @@ class ValidationDesign(BaseModel):
                                 "validation_arg_values": [typed_metadata_value],
                             }
                         ),
-                        cache_view=cache_view,
+                        type_annotations=type_annotations,
+                        dataset_label=dataset_label,
                     )
                 )
 
@@ -419,307 +325,13 @@ class ColumnValidation(BaseModel):
     nullable: bool
     validations: list[ValidationDesign] | None = None
 
-    @classmethod
-    def from_observable_property(
-        cls,
-        column_name: str,
-        observable_property: peh.ObservableProperty | pehs.ObservableProperty,
-        cache_view: CacheContainerView | None = None,
-    ) -> "ColumnValidation":
-        required = observable_property.default_required
-        nullable = not required
-        validations = []
-        assert isinstance(observable_property.value_type, str)
-        data_type = convert_peh_value_type_to_validation_dto_datatype(observable_property.value_type)
-        if validation_designs := getattr(observable_property, "validation_designs", None):
-            validations.extend([ValidationDesign.from_peh(vd, cache_view=cache_view) for vd in validation_designs])
-        if value_metadata := getattr(observable_property, "value_metadata", None):
-            validations.extend(ValidationDesign.list_from_metadata(value_metadata, cache_view=cache_view))
-        if getattr(observable_property, "categorical", None):
-            value_options = getattr(observable_property, "value_options", None)
-            assert (
-                value_options is not None
-            ), f"ObservableProperty {observable_property} lacks `value_options` for categorical type"
-            validation_arg_values: list[str] = [CategoricalString(vo.key) for vo in value_options]
-            validations.append(
-                ValidationDesign.from_peh(
-                    peh.ValidationDesign(
-                        validation_name="check_categorical",
-                        validation_expression=peh.ValidationExpression(
-                            validation_command=peh.ValidationCommand.is_in,
-                            validation_arg_values=validation_arg_values,
-                        ),
-                        validation_error_level=peh.ValidationErrorLevel.error,
-                    ),
-                    cache_view=cache_view,
-                )
-            )
-
-        assert isinstance(required, bool)
-        return cls(
-            unique_name=column_name,
-            data_type=data_type,
-            required=required,
-            nullable=nullable,
-            validations=validations,
-        )
-
 
 class ValidationConfig(BaseModel, Generic[T_DataType]):
     name: str
     columns: list[ColumnValidation]
     identifying_column_names: list[str] | None = None
     validations: list[ValidationDesign] | None = None
-    dependent_observable_property_ids: set[str] | None = None
-
-    # TODO: can be deprecated but tests need to be fixed
-    @classmethod
-    def from_peh(
-        cls,
-        observation_id: str,
-        observable_property_selection: Sequence[peh.ObservableProperty],
-        observation_design: peh.ObservationDesign | pehs.ObservationDesign,
-        dataset_validations: Sequence[peh.ValidationDesign] | None = None,
-        cache_view: CacheContainerView | None = None,
-    ) -> "ValidationConfig":
-        if isinstance(observation_design.required_observable_property_id_list, list) and isinstance(
-            observation_design.optional_observable_property_id_list, list
-        ):
-            assert isinstance(observation_design.identifying_observable_property_id_list, list)
-            assert isinstance(observation_design.required_observable_property_id_list, list)
-            assert isinstance(observation_design.optional_observable_property_id_list, list)
-            all_obsprop_ids = (
-                observation_design.identifying_observable_property_id_list
-                + observation_design.required_observable_property_id_list
-                + observation_design.optional_observable_property_id_list
-            )
-        else:
-            raise TypeError
-        local_obsprop_id_selection = [op.id for op in observable_property_selection]
-        local_obsprop_dict = {op.id: op for op in observable_property_selection}
-        columns = [
-            ColumnValidation.from_observable_property(op_id, local_obsprop_dict[op_id], cache_view)
-            for op_id in all_obsprop_ids
-            if op_id in local_obsprop_id_selection
-        ]
-
-        # figure out dependent_observable_property_ids
-        observable_property_id_set = set(all_obsprop_ids)
-        dependent_observable_property_ids = set()
-        expression_stack = []
-        for column_validation in columns:
-            validation_designs = getattr(column_validation, "validations", None)
-            if validation_designs is None:
-                continue
-            for validation_design in validation_designs:
-                expression = getattr(validation_design, "expression", None)
-                assert expression is not None
-                expression_stack.append(expression)
-
-        while expression_stack:
-            expression = expression_stack.pop()
-            conditional_expression = expression.conditional_expression
-            if conditional_expression is not None:
-                expression_stack.append(conditional_expression)
-            arg_expressions = expression.arg_expressions
-            if arg_expressions is not None:
-                for arg_expression in arg_expressions:
-                    expression_stack.append(arg_expression)
-            arg_columns = expression.arg_columns
-            if arg_columns is not None:
-                for arg_column in arg_columns:
-                    if arg_column not in observable_property_id_set:
-                        dependent_observable_property_ids.add(arg_column)
-            subject = expression.subject
-            if subject is not None:
-                for s in subject:
-                    if s not in observable_property_id_set:
-                        dependent_observable_property_ids.add(s)
-
-        validations = (
-            None
-            if dataset_validations is None
-            else [ValidationDesign.from_peh(v, cache_view) for v in dataset_validations]
-        )
-
-        # Optional: log or raise error if some op_ids are missing
-        missing = set(all_obsprop_ids) - set(local_obsprop_id_selection)
-        if missing:
-            raise ValueError(f"Missing observable properties for IDs: {missing}")
-        assert isinstance(observation_design.identifying_observable_property_id_list, list)
-
-        return cls(
-            name=observation_id,
-            columns=columns,
-            identifying_column_names=observation_design.identifying_observable_property_id_list,
-            validations=validations,
-            dependent_observable_property_ids=dependent_observable_property_ids,
-        )
-
-    # TODO: can be deprecated but tests need to be fixed
-    @classmethod
-    def from_observation(
-        cls,
-        observation: peh.Observation | pehs.Observation,
-        observable_property_selection: Sequence[peh.ObservableProperty],
-        dataset_validations: Sequence[peh.ValidationDesign] | None = None,
-        cache_view: CacheContainerView | None = None,
-    ) -> ValidationConfig:
-        observation_design = getattr(observation, "observation_design", None)
-        if observation_design is None:
-            logger.error(
-                "Cannot generate a ValidationConfig from an Observation that does not contain an ObservationDesign"
-            )
-            raise AttributeError
-
-        validation_config = cls.from_peh(
-            observation.id,
-            observable_property_selection,
-            observation_design,
-            dataset_validations,
-            cache_view,
-        )
-        return validation_config
-
-    @classmethod
-    def extract_dependent_columns(cls, column_validations: list[ColumnValidation]) -> set:
-        ret = set()
-        expression_stack = []
-
-        for column_validation in column_validations:
-            validation_designs = getattr(column_validation, "validations", None)
-            if validation_designs is None:
-                continue
-            for validation_design in validation_designs:
-                expression = getattr(validation_design, "expression", None)
-                assert expression is not None
-                expression_stack.append(expression)
-
-        while expression_stack:
-            expression = expression_stack.pop()
-            assert isinstance(expression, ValidationExpression)
-            conditional_expression = expression.conditional_expression
-            if conditional_expression is not None:
-                expression_stack.append(conditional_expression)
-            arg_expressions = expression.arg_expressions
-            if arg_expressions is not None:
-                for arg_expression in arg_expressions:
-                    expression_stack.append(arg_expression)
-            arg_columns = expression.arg_columns
-            if arg_columns is not None:
-                for arg_column in arg_columns:
-                    ret.add(arg_column)
-            subject = expression.subject
-            if subject is not None:
-                for s in subject:
-                    ret.add(s)
-
-        return ret
-
-    @classmethod
-    def apply_context_to_expressions(cls, expressions: list[ValidationExpression], context: dict[str, str]):
-        expression_stack = expressions
-        while expression_stack:
-            expression = expression_stack.pop()
-            assert isinstance(expression, ValidationExpression)
-            conditional_expression = expression.conditional_expression
-            if conditional_expression is not None:
-                expression_stack.append(conditional_expression)
-            arg_expressions = expression.arg_expressions
-            if arg_expressions is not None:
-                for arg_expression in arg_expressions:
-                    expression_stack.append(arg_expression)
-            arg_columns = expression.arg_columns
-            new_arg_columns = []
-            if arg_columns is not None:
-                for arg_column in arg_columns:
-                    new_arg_column = context.get(arg_column, None)
-                    if new_arg_column is not None:
-                        new_arg_columns.append(new_arg_column)
-                    else:
-                        new_arg_columns.append(arg_column)
-                expression.arg_columns = new_arg_columns
-            subject = expression.subject
-            if subject is not None:
-                new_subject = []
-                for s in subject:
-                    new_s = context.get(s, None)
-                    if new_s is not None:
-                        new_subject.append(new_s)
-                    else:
-                        new_subject.append(s)
-                expression.subject = new_subject
-
-    @classmethod
-    def apply_context_to_column_validations(cls, column_validations: list[ColumnValidation], context: dict[str, str]):
-        expression_stack = []
-
-        for column_validation in column_validations:
-            validation_designs = getattr(column_validation, "validations", None)
-            if validation_designs is None:
-                continue
-            for validation_design in validation_designs:
-                expression = getattr(validation_design, "expression", None)
-                assert expression is not None
-                expression_stack.append(expression)
-
-        cls.apply_context_to_expressions(expression_stack, context)
-
-    @classmethod
-    def from_dataset(
-        cls,
-        dataset: Dataset[T_DataType],
-        dataset_validations: Sequence[ValidationDesign] | None = None,
-        cache_view: CacheContainerView | None = None,
-    ) -> ValidationConfig:
-        # source path is dataset depedent
-        dataset_series = getattr(dataset, "part_of")
-        assert dataset_series is not None
-        # use typing information: dict uses {dataset_series_label: {dataset_label: type}}
-        # can then be accessed with contextual_field_references
-        # TODO: dataset_series_type_info = dataset_series.get_type_annotations()
-
-        column_validations = []
-        non_empty_columns = dataset.non_empty
-        assert non_empty_columns is not None
-        for non_empty_column in non_empty_columns:
-            dataset_element = dataset.get_schema_element_by_label(non_empty_column)
-            assert dataset_element is not None
-            observable_property_id = dataset_element.observable_property_id
-            observable_property = cache_view.get(observable_property_id, "ObservableProperty")
-            assert isinstance(observable_property, peh.ObservableProperty)
-            # TODO: should be ColumnValidation.from_dataset_element
-            column_validation = ColumnValidation.from_observable_property(
-                column_name=non_empty_column,
-                observable_property=observable_property,
-                cache_view=cache_view,
-            )
-            column_validations.append(column_validation)
-
-        dependent_observable_property_ids = cls.extract_dependent_columns(column_validations)
-        obs_prop_in_dataset = set(dataset.get_observable_property_ids())
-        cross_dataset_dependent_observable_property_ids = dependent_observable_property_ids - obs_prop_in_dataset
-
-        identifying_column_names = dataset.schema.primary_keys
-        assert identifying_column_names is not None
-
-        ## transform observable_property_ids to dataset_elements
-        # transform column_validations
-        context = dict()
-        for dataset_label in dataset_series.parts:
-            dataset = dataset_series[dataset_label]
-            for k, v in dataset.schema._elements_by_observable_property.items():
-                context[k] = v
-
-        _ = cls.apply_context_to_column_validations(column_validations, context)
-
-        return cls(
-            name=dataset.label,
-            columns=column_validations,
-            identifying_column_names=list(identifying_column_names),
-            validations=dataset_validations,
-            dependent_observable_property_ids=cross_dataset_dependent_observable_property_ids,
-        )
+    dependent_contextual_field_references: dict[str, set[str]] = defaultdict(set)
 
 
 class ValidationDTO(BaseModel):

--- a/tests/adapters/outbound/validation/pandera_adapter/input_arg_expression/arg_expression.yaml
+++ b/tests/adapters/outbound/validation/pandera_adapter/input_arg_expression/arg_expression.yaml
@@ -95,7 +95,8 @@ observable_properties:
   - validation_expression:
       validation_condition_expression:
         validation_subject_contextual_field_references:
-        - field_label: matrix
+        - dataset_label: matrix_chol
+          field_label: matrix
         validation_command: is_in
         validation_arg_values:
         - BWB
@@ -114,7 +115,8 @@ observable_properties:
         - VAMS
       validation_arg_expressions:
       - validation_subject_contextual_field_references:
-        - field_label: chol
+        - dataset_label: matrix_chol
+          field_label: chol
         validation_command: is_greater_than_or_equal_to
         validation_arg_values:
         - '50'
@@ -124,14 +126,16 @@ observable_properties:
   - validation_expression:
       validation_condition_expression:
         validation_subject_contextual_field_references:
-        - field_label: matrix
+        - dataset_label: matrix_chol
+          field_label: matrix
         validation_command: is_in
         validation_arg_values:
         - BM
         - BMG
       validation_arg_expressions:
       - validation_subject_contextual_field_references:
-        - field_label: chol
+        - dataset_label: matrix_chol
+          field_label: chol
         validation_command: is_greater_than_or_equal_to
         validation_arg_values:
         - '5'

--- a/tests/adapters/outbound/validation/pandera_adapter/input_check_command/check_command.yaml
+++ b/tests/adapters/outbound/validation/pandera_adapter/input_check_command/check_command.yaml
@@ -95,7 +95,8 @@ observable_properties:
   - validation_expression:
       validation_condition_expression:
         validation_subject_contextual_field_references:
-        - field_label: matrix
+        - dataset_label: matrix_chol
+          field_label: matrix
         validation_command: is_in
         validation_arg_values:
         - BWB
@@ -113,7 +114,8 @@ observable_properties:
         - DBS
         - VAMS
       validation_subject_contextual_field_references:
-        - field_label: chol
+        - dataset_label: matrix_chol
+          field_label: chol
       validation_command: is_greater_than_or_equal_to
       validation_arg_values:
         - '50'
@@ -123,13 +125,15 @@ observable_properties:
   - validation_expression:
       validation_condition_expression:
         validation_subject_contextual_field_references:
-        - field_label: matrix
+        - dataset_label: matrix_chol
+          field_label: matrix
         validation_command: is_in
         validation_arg_values:
         - BM
         - BMG
       validation_subject_contextual_field_references:
-        - field_label: chol
+        - dataset_label: matrix_chol
+          field_label: chol
       validation_command: is_greater_than_or_equal_to
       validation_arg_values:
         - '5'

--- a/tests/adapters/outbound/validation/pandera_adapter/test_validation_parsers.py
+++ b/tests/adapters/outbound/validation/pandera_adapter/test_validation_parsers.py
@@ -17,8 +17,15 @@ from pypeh.core.models.validation_dto import (
 )
 from pypeh.core.interfaces.outbound.dataops import ValidationInterface
 from pypeh.core.models.constants import ValidationErrorLevel
+from pypeh.core.models.internal_data_layout import (
+    Dataset,
+    DatasetSchema,
+    DatasetSchemaElement,
+    ObservablePropertyValueType,
+)
 from pypeh.core.cache.containers import CacheContainerFactory, CacheContainerView
 from pypeh.core.cache.utils import load_entities_from_tree
+
 from tests.test_utils.dirutils import get_absolute_path
 
 
@@ -319,32 +326,46 @@ class TestPehToDto:
         Checks whether using a single validation_command leads to the same
         validation configuration as using one validation_arg_expression.
         """
+        adapter = ValidationInterface.get_default_adapter_class()
+        adapter = adapter()
+        matrix_chol_schema = DatasetSchema(
+            elements={
+                "id_sample": DatasetSchemaElement(
+                    label="id_sample",
+                    observable_property_id="id_sample",
+                    data_type=ObservablePropertyValueType.STRING,
+                ),
+                "matrix": DatasetSchemaElement(
+                    label="matrix",
+                    observable_property_id="matrix",
+                    data_type=ObservablePropertyValueType.STRING,
+                ),
+                "chol": DatasetSchemaElement(
+                    label="chol",
+                    observable_property_id="chol",
+                    data_type=ObservablePropertyValueType.FLOAT,
+                ),
+            },
+            primary_keys=set("id_sample"),
+            foreign_keys={},
+        )
+
+        dataset = Dataset(
+            label="matrix_chol",
+            schema=matrix_chol_schema,
+        )
+        dataset.metadata["non_empty_dataset_elements"] = ["matrix", "chol"]
+
         check_command_cache_view = get_check_command_cache
-        check_command_obs_props = list(check_command_cache_view.get_all("ObservableProperty"))
-        check_command_observations = list(check_command_cache_view.get_all("Observation"))
-        observation_design_check = check_command_observations[0].observation_design
-
-        vc_check = ValidationConfig.from_peh(
-            "check",
-            check_command_obs_props,
-            observation_design_check,
-            cache_view=check_command_cache_view,
-        )
-
+        vc_check = adapter.build_validation_config(dataset=dataset, cache_view=check_command_cache_view)
         arg_expression_cache_view = get_arg_expression_cache
-        arg_expression_obs_props = list(arg_expression_cache_view.get_all("ObservableProperty"))
-        arg_expression_observations = list(arg_expression_cache_view.get_all("Observation"))
-        observation_design_arg = arg_expression_observations[0].observation_design
-
-        vc_arg = ValidationConfig.from_peh(
-            "arg",
-            arg_expression_obs_props,
-            observation_design_arg,
-            cache_view=arg_expression_cache_view,
-        )
+        vc_arg = adapter.build_validation_config(dataset=dataset, cache_view=arg_expression_cache_view)
 
         assert len(vc_check.columns) == len(vc_arg.columns)
+
         for check_col, arg_col in zip(vc_check.columns, vc_arg.columns):
+            assert check_col.validations is not None
+            assert arg_col.validations is not None
             assert len(check_col.validations) == len(arg_col.validations)
 
         parsed_vc_check = parse_config(vc_check)

--- a/tests/core/interfaces/outbound/dataops/input/ValidationExamples/validation_test_03_corrected_config.yaml
+++ b/tests/core/interfaces/outbound/dataops/input/ValidationExamples/validation_test_03_corrected_config.yaml
@@ -1,0 +1,324 @@
+import_configs:
+- id: peh:IMPORT_CONFIG_CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA
+  layout: peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA
+  section_mapping:
+    section_mapping_links:
+    - section: SAMPLE_METADATA_SECTION_SAMPLE
+      observation_id_list:
+      - peh:VALIDATION_TEST_SAMPLE_METADATA
+    - section: SAMPLE_METADATA_SECTION_SAMPLETIMEPOINT_BSS
+      observation_id_list:
+      - peh:VALIDATION_TEST_SAMPLE_TIMEPOINT
+observations:
+- id: peh:VALIDATION_TEST_SAMPLE_METADATA
+  name: VALIDATION_TEST_SAMPLE_METADATA
+  ui_label: SAMPLE
+  observation_type: metadata
+  observation_design:
+    observation_result_type: measurement
+    observable_entity_type: sample
+    identifying_observable_property_id_list:
+    - peh:id_sample
+    optional_observable_property_id_list:
+    - peh:samplingyear
+    - peh:samplingmonth
+    - peh:samplingday
+    - peh:samplinghour
+    - peh:samplingminutes
+    - peh:matrix
+- id: peh:VALIDATION_TEST_SAMPLE_TIMEPOINT
+  name: VALIDATION_TEST_SAMPLE_TIMEPOINT
+  ui_label: SAMPLETIMEPOINT_BSS
+  observation_type: sampling
+  observation_design:
+    observation_result_type: measurement
+    observable_entity_type: sample
+    identifying_observable_property_id_list:
+    - peh:id_sample
+    optional_observable_property_id_list:
+    - peh:chol
+    - peh:chol_lod
+    - peh:chol_loq
+layouts:
+- id: peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA
+  name: CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA
+  ui_label: SAMPLE_METADATA
+  sections:
+  - id: SAMPLE_METADATA_SECTION_SAMPLE
+    ui_label: SAMPLE
+    section_type: data_table
+    observable_entity_type: sample
+    elements:
+    - label: id_sample
+      observable_property: peh:id_sample
+      is_observable_entity_key: true
+    - label: samplingyear
+      observable_property: peh:samplingyear
+    - label: samplingmonth
+      observable_property: peh:samplingmonth
+    - label: samplingday
+      observable_property: peh:samplingday
+    - label: samplinghour
+      observable_property: peh:samplinghour
+    - label: samplingminutes
+      observable_property: peh:samplingminutes
+    - label: matrix
+      observable_property: peh:matrix
+  - id: SAMPLE_METADATA_SECTION_SAMPLETIMEPOINT_BSS
+    ui_label: SAMPLETIMEPOINT_BSS
+    section_type: data_table
+    observable_entity_type: sample
+    elements:
+    - label: id_sample
+      observable_property: peh:id_sample
+      is_observable_entity_key: true
+      foreign_key_link:
+        section: SAMPLE_METADATA_SECTION_SAMPLE
+        label: peh:id_sample
+    - label: chol
+      observable_property: peh:chol
+    - label: chol_lod
+      observable_property: peh:chol_lod
+    - label: chol_loq
+      observable_property: peh:chol_loq
+observable_properties:
+- id: peh:id_sample
+  unique_name: id_sample
+  name: id_sample
+  ui_label: id_sample
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: true
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:samplingyear
+  unique_name: samplingyear
+  name: samplingyear
+  description: year of sample collection
+  ui_label: samplingyear
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: true
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:samplingmonth
+  unique_name: samplingmonth
+  name: samplingmonth
+  description: month of sample collection (1 is the first month of the year)
+  ui_label: samplingmonth
+  value_type: string
+  categorical: true
+  multivalued: false
+  value_options:
+  - key: '1'
+    value: January
+  - key: '2'
+    value: February
+  - key: '3'
+    value: March
+  - key: '4'
+    value: April
+  - key: '5'
+    value: May
+  - key: '6'
+    value: June
+  - key: '7'
+    value: July
+  - key: '8'
+    value: August
+  - key: '9'
+    value: September
+  - key: '10'
+    value: October
+  - key: '11'
+    value: November
+  - key: '12'
+    value: December
+  default_unit: UNITLESS
+  default_required: false
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:samplingday
+  unique_name: samplingday
+  name: samplingday
+  description: day of sample collection (1 is the first day of the month)
+  ui_label: samplingday
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: false
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:samplinghour
+  unique_name: samplinghour
+  name: samplinghour
+  description: Hour of sampling
+  ui_label: samplinghour
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: false
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:samplingminutes
+  unique_name: samplingminutes
+  name: samplingminutes
+  description: Minutes of sampling
+  ui_label: samplingminutes
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: false
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+- id: peh:chol
+  unique_name: chol
+  name: chol
+  description: Cholesterol in sample
+  ui_label: Cholesterol in sample
+  remark: "measured values (X) are given;\n\n-10 = measurement was planned for a participant,\
+    \ but unexpected reasons prevented the sample to be measured (eg. not enough sample,\
+    \ broken tube, analytical issue, etc.)\n\n\n\nif LOD as well as LOQ is known:\
+    \ \n\n-1 for X < LOD\n\n-2 for LOD <= X < LOQ\n\nif LOQ is known, but LOD is not:\n\
+    \n-3 for X < LOQ\n\nif LOD is known, but LOQ is not:\n\n-1 for X < LOD"
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  value_metadata:
+  - field: id_line
+    value: '6'
+  - field: cb_source
+    value: basic
+  default_unit: MilliGM-PER-DeciL
+  default_unit_label: mg/dL
+  default_required: false
+  default_zeroallowed: true
+  default_significantdecimals: 6
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+  short_name: chol
+  validation_designs:
+  - validation_expression:
+      validation_condition_expression:
+        validation_subject_contextual_field_references:
+        - field_label: peh:matrix
+        validation_command: is_in
+        validation_arg_values:
+        - BWB
+        - BP
+        - BS
+        - CBWB
+        - CBP
+        - CBS
+        - BWBG
+        - BPG
+        - BSG
+        - CBWBG
+        - CBPG
+        - CBSG
+        - DBS
+        - VAMS
+      validation_arg_expressions:
+      - validation_subject_contextual_field_references:
+        - field_label: peh:chol
+        validation_command: is_greater_than_or_equal_to
+        validation_arg_values:
+        - '50'
+    conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS)\
+      \  THEN chol IS not empty; \n\nIF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS)\
+      \  THEN chol [50,250]; \n\nIF matrix IS (BM,BMG)  THEN chol [5,100]"
+  - validation_expression:
+      validation_condition_expression:
+        validation_subject_contextual_field_references:
+        - field_label: peh:matrix
+        validation_command: is_in
+        validation_arg_values:
+        - BM
+        - BMG
+      validation_arg_expressions:
+      - validation_subject_contextual_field_references:
+        - field_label: peh:chol
+        validation_command: is_greater_than_or_equal_to
+        validation_arg_values:
+        - '5'
+    conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS)\
+      \  THEN chol IS not empty; \n\nIF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS)\
+      \  THEN chol [50,250]; \n\nIF matrix IS (BM,BMG)  THEN chol [5,100]"
+- id: peh:chol_lod
+  unique_name: chol_lod
+  name: chol_lod
+  description: lod associated with the cholesterol measurement of the sample
+  ui_label: lod associated with the cholesterol measurement of the sample
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  value_metadata:
+  - field: id_line
+    value: '7'
+  - field: cb_source
+    value: basic
+  default_unit: MilliGM-PER-DeciL
+  default_unit_label: mg/dL
+  default_required: false
+  default_zeroallowed: true
+  default_significantdecimals: 6
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+  short_name: chol_lod
+- id: peh:chol_loq
+  unique_name: chol_loq
+  name: chol_loq
+  description: loq associated with the cholesterol measurement of the sample
+  ui_label: loq associated with the cholesterol measurement of the sample
+  value_type: decimal
+  categorical: false
+  multivalued: false
+  value_metadata:
+  - field: id_line
+    value: '8'
+  - field: cb_source
+    value: basic
+  default_unit: MilliGM-PER-DeciL
+  default_unit_label: mg/dL
+  default_required: false
+  default_zeroallowed: true
+  default_significantdecimals: 6
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+  short_name: chol_loq
+- id: peh:matrix
+  unique_name: matrix
+  name: matrix
+  ui_label: matrix
+  value_type: string
+  categorical: false
+  multivalued: false
+  default_unit: UNITLESS
+  default_required: false
+  default_zeroallowed: true
+  default_observation_result_type: measurement
+  relevant_observation_types:
+  - questionnaire
+  short_name: matrix

--- a/tests/core/interfaces/outbound/dataops/test_dataops.py
+++ b/tests/core/interfaces/outbound/dataops/test_dataops.py
@@ -41,6 +41,8 @@ class DataOpsProtocol(Protocol, Generic[T_DataType]):
 
     def import_data_layout(self, source, config) -> Any: ...
 
+    def build_validation_config(self, dataset, dataset_series, cache_view) -> ValidationConfig: ...
+
 
 class TestValidation(abc.ABC):
     """Abstract base class for testing dataops adapters."""
@@ -51,6 +53,24 @@ class TestValidation(abc.ABC):
     def get_adapter(self) -> DataOpsProtocol:
         """Return the adapter implementation to test."""
         raise NotImplementedError
+
+    def get_container(self, path: str, is_file=True) -> CacheContainerView:
+        source = get_absolute_path(path)
+        container = CacheContainerFactory.new()
+        host = DirectoryIO()
+        roots = host.load(source, format="yaml")
+        if is_file:
+            roots = [roots]
+        for root in roots:
+            for entity in load_entities_from_tree(root):
+                container.add(entity)
+
+        return CacheContainerView(container)
+
+    def get_container_validation_example_03(self) -> CacheContainerView:
+        src_path = "./input/ValidationExamples/validation_test_03_corrected_config.yaml"
+        cache_view = self.get_container(src_path)
+        return cache_view
 
     def test_getting_default_adapter_from_interface(self):
         adapter_class = ValidationInterface.get_default_adapter_class()
@@ -443,6 +463,24 @@ class TestValidation(abc.ABC):
         assert result.groups[0].name == expected_output.get("name")
         assert result.total_errors == expected_output.get("total_errors")
         assert result.error_counts == expected_output.get("errors_counts")
+
+    def test_build_validation_config(self):
+        adapter = self.get_adapter()
+        cache_view = self.get_container_validation_example_03()
+        data_layout = cache_view.get("peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA", "DataLayout")
+        assert isinstance(data_layout, DataLayout)
+        dataset_series = DatasetSeries.from_peh_datalayout(
+            data_layout=data_layout, cache_view=cache_view, apply_context=True
+        )
+        dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
+        assert dataset is not None
+        dataset.metadata["non_empty_dataset_elements"] = ["id_sample", "chol", "chol_lod", "chol_loq"]
+        validation_config = adapter.build_validation_config(
+            dataset=dataset,
+            dataset_series=dataset_series,
+            cache_view=cache_view,
+        )
+        assert isinstance(validation_config, ValidationConfig)
 
 
 class TestDataImport(abc.ABC):

--- a/tests/core/models/test_internal_datalayout.py
+++ b/tests/core/models/test_internal_datalayout.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pypeh.core.cache.containers import CacheContainerFactory, CacheContainerView
+from pypeh.core.cache.containers import CacheContainer, CacheContainerFactory, CacheContainerView
 from pypeh.core.models.internal_data_layout import (
     DatasetSeries,
     DatasetSchema,
@@ -19,7 +19,7 @@ from tests.test_utils.dirutils import get_absolute_path
 @pytest.mark.core
 class TestInternalDataLayout:
     @pytest.fixture(scope="class")
-    def get_cache(self):
+    def get_cache(self) -> CacheContainerView:
         source = get_absolute_path("input")
         container = CacheContainerFactory.new()
         host = DirectoryIO()
@@ -59,6 +59,30 @@ class TestInternalDataLayout:
         for key, subschema in expected_schema.items():
             for subkey, value in subschema.items():
                 assert schema[key][subkey] == value
+
+    def test_apply_context(self, get_cache):
+        cache_view = get_cache
+        layout_id = "peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA"
+        layout = get_cache.get(layout_id, "DataLayoutLayout")
+        all_sections = set()
+        for section in layout.sections:
+            section_id = section.id
+            if section.id is not None:
+                all_sections.add(section_id)
+        dataset_series = DatasetSeries.from_peh_datalayout(
+            layout,
+            cache_view=cache_view,
+        )
+        assert isinstance(dataset_series, DatasetSeries)
+
+        cache = cache_view._container
+        assert isinstance(cache, CacheContainer)
+        dataset_series.apply_context(cache)
+        adults_u_crt = cache_view.get("peh:adults_u_crt", "ObservableProperty")
+        expression = adults_u_crt.validation_designs[0].validation_expression
+        contextual_field_reference = expression.validation_subject_contextual_field_references[0]
+        assert contextual_field_reference.dataset_label == "SAMPLETIMEPOINT_BS"
+        assert contextual_field_reference.field_label == "adults_u_crt"
 
 
 class TestJoinConditions:

--- a/tests/core/models/test_validation_dto.py
+++ b/tests/core/models/test_validation_dto.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pypeh.adapters.outbound.persistence.hosts import DirectoryIO
+from pypeh.core.interfaces.outbound.dataops import ValidationInterface
 from pypeh.core.cache.containers import CacheContainerFactory, CacheContainerView
 from pypeh.core.cache.utils import load_entities_from_tree
 from pypeh.core.models.internal_data_layout import DatasetSeries
@@ -23,6 +24,7 @@ class TestBasicValidationConfig:
         return CacheContainerView(container)
 
     def test_config_from_dataset(self, get_cache):
+        validation_interface = ValidationInterface()
         cache_view = get_cache
         layout_id = "peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA"
         layout = cache_view.get(layout_id, "DataLayoutLayout")
@@ -59,8 +61,9 @@ class TestBasicValidationConfig:
             dataset_series.add_data(dataset_label, fake_dataset, non_empty_dataset_elements=list(fake_dataset.keys()))
 
         for dataset_label, dataset in dataset_series.parts.items():
-            config = ValidationConfig.from_dataset(
+            config = validation_interface.build_validation_config(
                 dataset=dataset,
+                dataset_series=dataset_series,
                 cache_view=cache_view,
             )
             assert isinstance(config, ValidationConfig)

--- a/tests/end_to_end/validation/input/test_06/config/validation_test_06_config_02_layouts.yaml
+++ b/tests/end_to_end/validation/input/test_06/config/validation_test_06_config_02_layouts.yaml
@@ -36,7 +36,8 @@ layouts:
       validation_error_level: error
       validation_expression:
         validation_subject_contextual_field_references:
-        - field_label: id_subject
+        - dataset_label: SAMPLE
+          field_label: id_subject
         validation_command: is_in
         validation_arg_contextual_field_references:
         - dataset_label: SUBJECTUNIQUE
@@ -45,7 +46,8 @@ layouts:
       validation_error_level: error
       validation_expression:
         validation_subject_contextual_field_references:
-        - field_label: id_sample
+        - dataset_label: SAMPLE
+          field_label: id_sample
         validation_command: is_in
         validation_arg_contextual_field_references:
         - dataset_label: SAMPLETIMEPOINT_BWB
@@ -79,7 +81,8 @@ layouts:
       validation_error_level: error
       validation_expression:
         validation_subject_contextual_field_references:
-        - field_label: id_participant
+        - dataset_label: SUBJECTUNIQUE
+          field_label: id_participant
         validation_command: is_in
         validation_arg_contextual_field_references:
         - dataset_label: SUBJECTUNIQUE
@@ -106,7 +109,8 @@ layouts:
       validation_error_level: error
       validation_expression:
         validation_subject_contextual_field_references:
-        - field_label: id_sample
+        - dataset_label: SAMPLETIMEPOINT_BWB
+          field_label: id_sample
         validation_command: is_in
         validation_arg_contextual_field_references:
         - dataset_label: SAMPLE

--- a/tests/end_to_end/validation/test_dataframe_consistency_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_consistency_validation.py
@@ -38,7 +38,9 @@ class TestDatasetConsistency:
         )
         assert data_import_config.id == "peh:IMPORT_CONFIG_CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA"
         assert isinstance(data_import_config, peh.DataImportConfig)
-        data_layout = session.cache.get(data_import_config.layout, "DataLayout")
+        layout_id = data_import_config.layout
+        assert layout_id is not None
+        data_layout = session.cache.get(layout_id, "DataLayout")
         assert data_layout.id == data_import_config.layout
         assert isinstance(data_layout, peh.DataLayout)
         dataset_series = session.load_tabular_dataset_series(

--- a/tests/end_to_end/validation/test_dataframe_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_validation.py
@@ -105,6 +105,7 @@ class TestRoundTripDataset:
         assert dataset is not None
         validation_report = session.validate_tabular_dataset(
             data=dataset,
+            dependent_data=dataset_series,
         )
         assert validation_report is not None
         assert isinstance(validation_report, ValidationErrorReport)


### PR DESCRIPTION
This PR refactors the validation logic such that none of the validation config logic has to deal with converting labels/identifiers. Adding in context (via the contextual field references) happens prior to building the config.
Currently this is done with an explicit `DatasetSeries.apply_context()`. In the future, this will be taken care of by the `ContextualObservableProperties`.