### PR TITLE
Fixed naming on validation generated from metadata fields

### DIFF
--- a/src/pypeh/core/models/validation_dto.py
+++ b/src/pypeh/core/models/validation_dto.py
@@ -236,7 +236,7 @@ class ValidationDesign(BaseModel):
         type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
         dataset_label: str | None = None,
     ) -> list["ValidationDesign"]:
-        expression_list = []
+        name_expression_list = []
         numeric_commands = set(
             [
                 "min",
@@ -299,22 +299,25 @@ class ValidationDesign(BaseModel):
                     generate = True
 
             if generate:
-                expression_list.append(
-                    ValidationExpression.from_peh(
-                        pehs.ValidationExpression.model_construct(
-                            **{
-                                "validation_command": validation_command,
-                                "validation_arg_values": [typed_metadata_value],
-                            }
+                name_expression_list.append(
+                    (
+                        metadatum.field.lower(),
+                        ValidationExpression.from_peh(
+                            pehs.ValidationExpression.model_construct(
+                                **{
+                                    "validation_command": validation_command,
+                                    "validation_arg_values": [typed_metadata_value],
+                                }
+                            ),
+                            type_annotations=type_annotations,
+                            dataset_label=dataset_label,
                         ),
-                        type_annotations=type_annotations,
-                        dataset_label=dataset_label,
                     )
                 )
 
         return [
-            cls(name=metadatum.field.lower(), error_level=ValidationErrorLevel.ERROR, expression=expression)
-            for expression in expression_list
+            cls(name=name, error_level=ValidationErrorLevel.ERROR, expression=expression)
+            for name, expression in name_expression_list
         ]
 
 

--- a/tests/core/interfaces/outbound/dataops/test_dataops.py
+++ b/tests/core/interfaces/outbound/dataops/test_dataops.py
@@ -1,4 +1,3 @@
-from re import L, U
 import pytest
 import abc
 

--- a/tests/core/models/test_internal_datalayout.py
+++ b/tests/core/models/test_internal_datalayout.py
@@ -288,12 +288,12 @@ class TestToTarget:
             observations=set(["peh:urine_lab_this"]),
         )
 
-        urine_lab_dataset = Dataset(
-            label="urine_lab",
-            schema=urine_lab_schema,
-            data=None,
-            observations=set(["peh:urine_lab_this", "peh:urine_lab_other"]),
-        )
+        # urine_lab_dataset = Dataset(
+        #     label="urine_lab",
+        #     schema=urine_lab_schema,
+        #     data=None,
+        #     observations=set(["peh:urine_lab_this", "peh:urine_lab_other"]),
+        # )
 
         analyticalinfo_dataset = Dataset(
             label="analyticalinfo",

--- a/tests/core/models/test_validation_dto.py
+++ b/tests/core/models/test_validation_dto.py
@@ -60,10 +60,26 @@ class TestBasicValidationConfig:
         for dataset_label, fake_dataset in fake_dataset_series.items():
             dataset_series.add_data(dataset_label, fake_dataset, non_empty_dataset_elements=list(fake_dataset.keys()))
 
-        for dataset_label, dataset in dataset_series.parts.items():
-            config = validation_interface.build_validation_config(
-                dataset=dataset,
-                dataset_series=dataset_series,
-                cache_view=cache_view,
-            )
-            assert isinstance(config, ValidationConfig)
+        sample_dataset = dataset_series.parts.get("SAMPLE", None)
+        sample_config = validation_interface.build_validation_config(
+            dataset=sample_dataset,
+            dataset_series=dataset_series,
+            cache_view=cache_view,
+        )
+        assert isinstance(sample_config, ValidationConfig)
+        assert [c.unique_name for c in sample_config.columns] == ["id_sample", "matrix"]
+        assert sample_config.columns[1].validations[0].name == "check_categorical"
+        assert sample_config.columns[1].validations[0].expression.command == "is_in"
+
+        sample_tp_dataset = dataset_series.parts.get("SAMPLETIMEPOINT_BS", None)
+        sample_tp_config = validation_interface.build_validation_config(
+            dataset=sample_tp_dataset,
+            dataset_series=dataset_series,
+            cache_view=cache_view,
+        )
+        assert isinstance(sample_tp_config, ValidationConfig)
+        assert [c.unique_name for c in sample_tp_config.columns] == ["id_sample", "adults_u_crt"]
+        assert sample_tp_config.columns[1].validations[1].name == "min"
+        assert sample_tp_config.columns[1].validations[1].expression.command == "is_greater_than_or_equal_to"
+        assert sample_tp_config.columns[1].validations[2].name == "max"
+        assert sample_tp_config.columns[1].validations[2].expression.command == "is_less_than_or_equal_to"

--- a/tests/end_to_end/validation/test_dataframe_validation.py
+++ b/tests/end_to_end/validation/test_dataframe_validation.py
@@ -2,8 +2,6 @@ import pytest
 import peh_model.peh as peh
 import logging
 
-from pypeh.core.cache.containers import CacheContainerView
-from pypeh.core.interfaces.outbound.dataops import DataImportInterface
 from pypeh.core.models.constants import ObservablePropertyValueType, ValidationErrorLevel
 from tests.test_utils.dirutils import get_absolute_path
 


### PR DESCRIPTION
Validation checks were created in accordance with the configured metadata fields, but the autogenerated naming was incorrect. It was taken from the last field in the list rather than being assigned as part the for loop.