### PR TITLE
add split_dataset_series_by_observation docs

### DIFF
--- a/docs/session-reference.md
+++ b/docs/session-reference.md
@@ -124,6 +124,19 @@ Read pypeh semantic parquet files previously produced by
 paths, such as the list returned by `dump_tabular_dataset_series`.
 
 ```python
+split_dataset_series_by_observation(
+    source_dataset_series: DatasetSeries,
+    new_dataset_series_label: str | None = None,
+    adapter_label: str = "dataops",
+) -> DatasetSeries
+```
+
+Return a new `DatasetSeries` whose datasets are organized by observation. The
+method delegates to the registered data-operations adapter. When
+`new_dataset_series_label` is omitted, the adapter derives a label from the
+source series label.
+
+```python
 validate_tabular_dataset(
     data: Dataset,
     dependent_data: DatasetSeries | None = None,

--- a/docs/session.md
+++ b/docs/session.md
@@ -188,6 +188,42 @@ Both methods currently support `file_format="parquet"` only. Reading validates
 foreign-key references by default; set `validate_foreign_keys=False` when
 loading a partial subset intentionally.
 
+## Split Data by Observation
+
+Use `split_dataset_series_by_observation` to normalize an imported
+`DatasetSeries` into observation-specific datasets. This is useful when source
+files were organized for collection or import, but downstream validation,
+enrichment, or export workflows should operate on one observation at a time.
+
+```python
+observation_dataset_series = session.split_dataset_series_by_observation(
+    source_dataset_series=dataset_series,
+)
+```
+
+The method delegates to the registered data-operations adapter. The adapter
+uses the `DatasetSeries` schema, observation membership, contextual field
+references, and foreign-key metadata to construct a new `DatasetSeries`.
+
+Datasets that contain fields for multiple observations may be split apart. If
+fields for one observation are spread across multiple datasets, the adapter can
+join those fields into one output dataset when the `DatasetSeries` declares the
+required foreign-key links.
+
+Pass `new_dataset_series_label` when you want to control the returned series
+label:
+
+```python
+observation_dataset_series = session.split_dataset_series_by_observation(
+    source_dataset_series=dataset_series,
+    new_dataset_series_label="study_by_observation",
+)
+```
+
+The returned `DatasetSeries` contains datasets organized by observation. Each
+output dataset is associated with one observation and contains the fields
+relevant to that observation.
+
 ## Validate Tabular Data
 
 Validate one dataset:

--- a/src/pypeh/core/session/session.py
+++ b/src/pypeh/core/session/session.py
@@ -702,6 +702,7 @@ class Session(Generic[T_AdapterType, T_DataType]):
         new_dataset_series_label: str | None = None,
         adapter_label: str = "dataops",
     ) -> DatasetSeries[T_DataType]:
+        """Split a DatasetSeries into observation-specific datasets."""
         adapter = self.get_adapter(adapter_label)
         assert isinstance(adapter, DataOpsInterface)
         ret = adapter.split_by_observation(


### PR DESCRIPTION
Adds documentation for the session-based split_dataset_series_by_observation.