### PR TITLE
add cache.require method

### DIFF
--- a/src/pypeh/core/cache/containers.py
+++ b/src/pypeh/core/cache/containers.py
@@ -30,6 +30,21 @@ logger = logging.getLogger(__name__)
 T_Container = TypeVar("T_Container")
 
 
+class ResourceNotFoundInCacheError(LookupError):
+    """Raised when a required PEH resource is missing from the cache."""
+
+    def __init__(self, entity_id: str, entity_type: str | None = None):
+        self.entity_id = entity_id
+        self.entity_type = entity_type
+        entity_type_label = (
+            f" of type '{entity_type}'" if entity_type is not None else ""
+        )
+        super().__init__(
+            f"Required resource{entity_type_label} with id "
+            f"'{entity_id}' was not found in the cache."
+        )
+
+
 class CacheContainer(ABC, Generic[T_Container]):
     """Abstract base class for cache backends"""
 
@@ -48,6 +63,15 @@ class CacheContainer(ABC, Generic[T_Container]):
     ) -> T_NamedThingLike:
         """Retrieve an entity"""
         pass
+
+    def require(
+        self, entity_id: str, entity_type: str | None = None
+    ) -> T_NamedThingLike:
+        """Retrieve an entity or raise when it is missing."""
+        ret = self.get(entity_id, entity_type)
+        if ret is None:
+            raise ResourceNotFoundInCacheError(entity_id, entity_type)
+        return ret
 
     @abstractmethod
     def get_all(
@@ -105,8 +129,7 @@ class CacheContainerView(Generic[T_Container]):
         if isinstance(container_subset, list):
             container_dict = defaultdict(list)
             for entity_id in container_subset:
-                entity = container.get(entity_id)
-                assert entity is not None
+                entity = container.require(entity_id)
                 entity_type = get_entity_type(entity)
                 container_dict[entity_type].append(entity_id)
             container_subset = container_dict
@@ -119,6 +142,11 @@ class CacheContainerView(Generic[T_Container]):
         self, entity_id: str, entity_type: str | None = None
     ) -> Optional[T_NamedThingLike]:
         return self._container.get(entity_id, entity_type)
+
+    def require(
+        self, entity_id: str, entity_type: str | None = None
+    ) -> T_NamedThingLike:
+        return self._container.require(entity_id, entity_type)
 
     def get_all(
         self, entity_type: str | None = None

--- a/src/pypeh/core/interfaces/dataops.py
+++ b/src/pypeh/core/interfaces/dataops.py
@@ -228,16 +228,16 @@ class DataOpsInterface(Generic[T_DataType]):
         ret = {}
         observation_design_id = observation.observation_design
         assert isinstance(observation_design_id, str)
-        observation_design = cache_view.get(
+        observation_design = cache_view.require(
             observation_design_id, "ObservationDesign"
         )
-        assert observation_design is not None
+        assert isinstance(observation_design, peh.ObservationDesign)
         observable_property_specs = (
             observation_design.observable_property_specifications
         )
         assert observable_property_specs is not None
         for observable_property_spec in observable_property_specs:
-            observable_property = cache_view.get(
+            observable_property = cache_view.require(
                 observable_property_spec.observable_property,
                 "ObservableProperty",
             )
@@ -754,7 +754,7 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
 
         validations = []
         observable_property_id = dataset_schema_element.observable_property_id
-        observable_property = cache_view.get(
+        observable_property = cache_view.require(
             observable_property_id, "ObservableProperty"
         )
         assert isinstance(
@@ -929,8 +929,9 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
         if layout_section_id is None:
             return None
         assert isinstance(layout_section_id, str)
-        layout_section = cache_view.get(layout_section_id, "DataLayoutSection")
-        assert layout_section is not None
+        layout_section = cache_view.require(
+            layout_section_id, "DataLayoutSection"
+        )
         assert isinstance(layout_section, peh.DataLayoutSection)
         if layout_section.validation_designs:
             for vd in layout_section.validation_designs:
@@ -1332,7 +1333,7 @@ class DataEnrichmentInterface(DataOpsInterface, Generic[T_DataType]):
             assert isinstance(
                 observation.observation_design, peh.ObservationDesignId
             )
-            observation_design = cache_view.get(
+            observation_design = cache_view.require(
                 observation.observation_design, "ObservationDesign"
             )
             assert isinstance(observation_design, peh.ObservationDesign)
@@ -1355,7 +1356,7 @@ class DataEnrichmentInterface(DataOpsInterface, Generic[T_DataType]):
                     observable_property_spec.observable_property,
                     (peh.ObservablePropertyId, str),
                 ):
-                    observable_property = cache_view.get(
+                    observable_property = cache_view.require(
                         observable_property_spec.observable_property,
                         "ObservableProperty",
                     )
@@ -1525,8 +1526,7 @@ class DataEnrichmentInterface(DataOpsInterface, Generic[T_DataType]):
         all_observations = []
         for nested_observations in source_dataset_series.observations.values():
             for observation_id in nested_observations:
-                observation = cache_view.get(observation_id, "Observation")
-                assert observation is not None
+                observation = cache_view.require(observation_id, "Observation")
                 all_observations.append(observation)
 
         dependency_graph = self.build_dependency_graph(
@@ -1654,7 +1654,7 @@ class AggregationInterface(DataOpsInterface, Generic[T_DataType]):
                 target_observation.observation_design
             )
             assert isinstance(target_observation_design_id, str)
-            target_observation_design = cache_view.get(
+            target_observation_design = cache_view.require(
                 target_observation_design_id, "ObservationDesign"
             )
             assert isinstance(target_observation_design, peh.ObservationDesign)
@@ -1671,7 +1671,7 @@ class AggregationInterface(DataOpsInterface, Generic[T_DataType]):
                     observable_property_spec.observable_property
                 )
                 assert isinstance(observable_property_id, str)
-                observable_property = cache_view.get(
+                observable_property = cache_view.require(
                     observable_property_id, "ObservableProperty"
                 )
                 assert isinstance(observable_property, peh.ObservableProperty)

--- a/src/pypeh/core/models/internal_data_layout.py
+++ b/src/pypeh/core/models/internal_data_layout.py
@@ -245,7 +245,7 @@ class DatasetSchema:
         """
         for schema_element in self.elements.values():
             observable_property_id = schema_element.observable_property_id
-            observable_property = cache.get(
+            observable_property = cache.require(
                 observable_property_id, "ObservableProperty"
             )
             assert isinstance(observable_property, peh.ObservableProperty)
@@ -680,7 +680,7 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                 observation_id = str(ULID())
                 if id_factory is not None:
                     observation_id = id_factory()
-                observable_property = cache_view.get(
+                observable_property = cache_view.require(
                     observable_property_id, "ObservableProperty"
                 )
                 assert isinstance(observable_property, peh.ObservableProperty)
@@ -703,10 +703,9 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                     assert isinstance(section_id, str)
                     foreign_key_element_label = foreign_key.label
                     assert foreign_key_element_label is not None
-                    section = cache_view.get(section_id, "DataLayoutSection")
-                    assert (
-                        section is not None
-                    ), f"section with id {section_id} cannot be found"
+                    section = cache_view.require(
+                        section_id, "DataLayoutSection"
+                    )
                     foreign_key_dataset_label = section.ui_label
                     assert (
                         foreign_key_dataset_label is not None
@@ -731,7 +730,7 @@ class DatasetSeries(Resource, Generic[T_DataType]):
     ) -> DatasetSeries:
         data_layout_id = data_import_config.layout
         assert data_layout_id is not None
-        data_layout = cache_view.get(data_layout_id, "DataLayout")
+        data_layout = cache_view.require(data_layout_id, "DataLayout")
         assert isinstance(data_layout, peh.DataLayout)
         layout_label = data_layout.ui_label
         if layout_label is None:
@@ -751,7 +750,9 @@ class DatasetSeries(Resource, Generic[T_DataType]):
             assert isinstance(link, peh.DataImportSectionMappingLink)
             section_id = link.section
             assert isinstance(section_id, str)
-            layout_section = cache_view.get(section_id, "DataLayoutSection")
+            layout_section = cache_view.require(
+                section_id, "DataLayoutSection"
+            )
             assert isinstance(layout_section, peh.DataLayoutSection)
             dataset_label = layout_section.ui_label
             assert dataset_label is not None
@@ -765,13 +766,13 @@ class DatasetSeries(Resource, Generic[T_DataType]):
             assert isinstance(observation_ids, list)
             for observation_id in observation_ids:
                 # observation_observable_properties
-                observation = cache_view.get(observation_id, "Observation")
+                observation = cache_view.require(observation_id, "Observation")
                 assert isinstance(observation, peh.Observation)
                 observation_design_id = observation.observation_design
                 assert isinstance(
                     observation_design_id, peh.ObservationDesignId
                 )
-                observation_design = cache_view.get(
+                observation_design = cache_view.require(
                     observation_design_id, "ObservationDesign"
                 )
                 assert isinstance(observation_design, peh.ObservationDesign)
@@ -801,7 +802,7 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                         assert element_label is not None
                         obs_prop_id = element.observable_property
                         assert isinstance(obs_prop_id, str)
-                        obs_prop = cache_view.get(
+                        obs_prop = cache_view.require(
                             obs_prop_id, "ObservableProperty"
                         )
                         assert isinstance(obs_prop, peh.ObservableProperty)
@@ -822,12 +823,9 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                             assert isinstance(section_id, str)
                             foreign_key_element_label = foreign_key.label
                             assert foreign_key_element_label is not None
-                            section = cache_view.get(
+                            section = cache_view.require(
                                 section_id, "DataLayoutSection"
                             )
-                            assert (
-                                section is not None
-                            ), f"section with id {section_id} cannot be found"
                             foreign_key_dataset_label = section.ui_label
                             assert (
                                 foreign_key_dataset_label is not None
@@ -838,7 +836,7 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                                 foreign_key_element_label=foreign_key_element_label,
                             )
 
-                observation = cache_view.get(observation_id)
+                observation = cache_view.require(observation_id)
                 assert isinstance(observation, peh.Observation)
                 ret.add_observation(
                     dataset_label=dataset_label,
@@ -940,7 +938,7 @@ class DatasetSeries(Resource, Generic[T_DataType]):
                 observable_property_specification.observable_property
             )
             assert isinstance(observable_property_id, str)
-            observable_property = cache_view.get(
+            observable_property = cache_view.require(
                 observable_property_id, "ObservableProperty"
             )
             assert isinstance(observable_property, peh.ObservableProperty)

--- a/src/pypeh/core/session/session.py
+++ b/src/pypeh/core/session/session.py
@@ -576,7 +576,7 @@ class Session(Generic[T_AdapterType, T_DataType]):
                 assert ret
 
             # resource should have been loaded into cache
-            ret = self.get_resource(resource_identifier, resource_type)
+            ret = self.cache.require(resource_identifier, resource_type)
             type_to_cast = getattr(peh, resource_type)
             assert isinstance(ret, type_to_cast)
         else:
@@ -677,7 +677,7 @@ class Session(Generic[T_AdapterType, T_DataType]):
         self,
         observation_group_id: str,
     ) -> Generator[tuple[peh.DerivedObservation, peh.Observation], None, None]:
-        observation_group = self.cache.get(
+        observation_group = self.cache.require(
             observation_group_id, "ObservationGroup"
         )
         assert isinstance(observation_group, peh.ObservationGroup)
@@ -689,7 +689,7 @@ class Session(Generic[T_AdapterType, T_DataType]):
             if isinstance(target_observation, peh.DerivedObservation):
                 source_observation_id = target_observation.was_derived_from
                 assert isinstance(source_observation_id, str)
-                source_observation = self.cache.get(
+                source_observation = self.cache.require(
                     source_observation_id, "Observation"
                 )
                 assert isinstance(source_observation, peh.Observation)

--- a/tests/core/cache/test_cache.py
+++ b/tests/core/cache/test_cache.py
@@ -11,6 +11,7 @@ from pypeh.core.cache.containers import (
     CacheContainer,
     CacheContainerFactory,
     CacheContainerView,
+    ResourceNotFoundInCacheError,
 )
 from pypeh.core.cache.utils import load_entities_from_tree
 from pypeh.adapters.persistence.hosts import DirectoryIO
@@ -78,3 +79,24 @@ class TestCache:
         assert len(ret.observations) > 0
         assert isinstance(ret.observable_properties, list)
         assert len(ret.observable_properties) > 0
+
+    def test_get_missing_resource_returns_none(self, container):
+        assert container.get("missing-resource", "Observation") is None
+
+    def test_require_missing_resource_raises_dedicated_error(self, container):
+        with pytest.raises(ResourceNotFoundInCacheError) as exc_info:
+            container.require("missing-resource", "Observation")
+
+        assert "missing-resource" in str(exc_info.value)
+        assert "Observation" in str(exc_info.value)
+
+    def test_cache_view_require_missing_resource_raises_dedicated_error(
+        self, container
+    ):
+        cache_view = CacheContainerView(container)
+
+        with pytest.raises(ResourceNotFoundInCacheError) as exc_info:
+            cache_view.require("missing-resource", "Observation")
+
+        assert "missing-resource" in str(exc_info.value)
+        assert "Observation" in str(exc_info.value)


### PR DESCRIPTION
Adds a `CacheContainer.require()` and `CacheContainerView.require()` method raising an informative `LookupError` whenever a required resources is not found in the cache.