### PR TITLE
setup split with label

### DIFF
--- a/src/pypeh/core/interfaces/dataops.py
+++ b/src/pypeh/core/interfaces/dataops.py
@@ -15,9 +15,11 @@ from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from peh_model import peh
-from typing import TYPE_CHECKING, Callable, Generic, Literal
+from typing import TYPE_CHECKING, Callable, Generic, Literal, Sequence
 
-from pypeh.core.cache.containers import CacheContainerView
+from pypeh.core.cache.containers import (
+    CacheContainerView,
+)
 from pypeh.core.models.constants import ObservablePropertyValueType
 from pypeh.core.models.internal_data_layout import (
     Dataset,
@@ -31,7 +33,7 @@ from pypeh.core.models import graph, validation_dto
 from pypeh.core.utils.function_utils import _extract_callable
 
 if TYPE_CHECKING:
-    from typing import Sequence, Any
+    from typing import Any
     from pypeh.core.models.validation_errors import ValidationErrorReport
 
 logger = logging.getLogger(__name__)
@@ -531,17 +533,13 @@ class DataOpsInterface(Generic[T_DataType]):
         source_series: DatasetSeries[T_DataType],
         observation_id: str,
         source_dataset_labels: list[str],
+        target_dataset_label: str,
         observable_property_context: dict[str, tuple[str, str]],
         final_fields_by_observable_property: dict[str, str],
         final_data: T_DataType,
     ) -> None:
-        output_dataset_label = self._build_unique_label(
-            observation_id,
-            set(target_series.parts.keys()),
-            dataset_label="observation",
-        )
         output_dataset = target_series.add_empty_dataset(
-            output_dataset_label,
+            target_dataset_label,
             metadata={
                 "source_datasets": source_dataset_labels,
                 "observation_id": observation_id,
@@ -578,11 +576,51 @@ class DataOpsInterface(Generic[T_DataType]):
 
         output_dataset.data = final_data
 
+    @staticmethod
+    def _resolve_observation_dataset_label(
+        observation: peh.Observation,
+        fallback_id: str,
+    ) -> str:
+        for label_field in ("ui_label", "short_name"):
+            label = getattr(observation, label_field, None)
+            if isinstance(label, str) and len(label) > 0:
+                return label
+        return fallback_id
+
+    def _build_target_dataset_labels_by_observation(
+        self,
+        observation_ids: Sequence[str],
+        cache_view: CacheContainerView,
+    ) -> dict[str, str]:
+        labels_by_observation: dict[str, str] = {}
+        observation_by_label: dict[str, str] = {}
+
+        for observation_id in observation_ids:
+            observation = cache_view.require(observation_id)
+            assert isinstance(observation, peh.Observation)
+            label = self._resolve_observation_dataset_label(
+                observation, fallback_id=observation_id
+            )
+
+            if label in observation_by_label:
+                raise ValueError(
+                    "Observation labels used as split dataset labels must be "
+                    f"unique. Label '{label}' resolved for observations "
+                    f"'{observation_by_label[label]}' and "
+                    f"'{observation_id}'."
+                )
+
+            labels_by_observation[observation_id] = label
+            observation_by_label[label] = observation_id
+
+        return labels_by_observation
+
     def split_by_observation(
         self,
         dataset_series: DatasetSeries[T_DataType],
         *,
         new_label: str | None = None,
+        cache_view: CacheContainerView | None = None,
     ) -> DatasetSeries[T_DataType]:
         """
         Return a new DatasetSeries where each Dataset maps to exactly one Observation.
@@ -603,6 +641,14 @@ class DataOpsInterface(Generic[T_DataType]):
         )
 
         observation_ids = sorted(dataset_series._obs_index.keys())
+        target_dataset_labels: dict[str, str] | None = None
+        if cache_view is not None:
+            target_dataset_labels = (
+                self._build_target_dataset_labels_by_observation(
+                    observation_ids, cache_view
+                )
+            )
+
         for observation_id in observation_ids:
             source_dataset_labels = sorted(
                 dataset_series._obs_index.get(observation_id, set())
@@ -679,11 +725,18 @@ class DataOpsInterface(Generic[T_DataType]):
             ]
             final_data = self.subset(joined_data, element_group=final_fields)
 
+            target_dataset_label = (
+                target_dataset_labels[observation_id]
+                if target_dataset_labels is not None
+                else observation_id
+            )
+
             self._build_output_dataset_for_observation(
                 target_series=ret,
                 source_series=dataset_series,
                 observation_id=observation_id,
                 source_dataset_labels=source_dataset_labels,
+                target_dataset_label=target_dataset_label,
                 observable_property_context=observable_property_context,
                 final_fields_by_observable_property=final_fields_by_observable_property,
                 final_data=final_data,

--- a/src/pypeh/core/session/session.py
+++ b/src/pypeh/core/session/session.py
@@ -717,10 +717,12 @@ class Session(Generic[T_AdapterType, T_DataType]):
     ) -> DatasetSeries[T_DataType]:
         """Split a DatasetSeries into observation-specific datasets."""
         adapter = self.get_adapter(adapter_label)
+        cache_view = CacheContainerView(self.cache)
         assert isinstance(adapter, DataOpsInterface)
         ret = adapter.split_by_observation(
             dataset_series=source_dataset_series,
             new_label=new_dataset_series_label,
+            cache_view=cache_view,
         )
         assert isinstance(ret, DatasetSeries)
         return ret

--- a/tests/core/interfaces/dataops/test_dataops.py
+++ b/tests/core/interfaces/dataops/test_dataops.py
@@ -78,6 +78,7 @@ class DataOpsProtocol(Protocol, Generic[T_DataType]):
         dataset_series: DatasetSeries[T_DataType],
         *,
         new_label: str | None = None,
+        cache_view: CacheContainerView | None = None,
     ) -> DatasetSeries[T_DataType]: ...
 
     def enrich(
@@ -1018,6 +1019,96 @@ class TestDatasetSeriesMods(abc.ABC):
         assert len(split_series.parts["obs:1"].observation_ids) == 1
         assert len(split_series.parts["obs:2"].observation_ids) == 1
         self.verify_join_and_single_dataset(split_series, adapter)
+
+    def test_split_by_observation_uses_observation_label_from_cache(self):
+        adapter = self.get_adapter()
+        dataset_series = DatasetSeries(label="labeled_split_case")
+        dataset = dataset_series.add_empty_dataset("source")
+        dataset.add_observation_to_index("obs:ui")
+        dataset.add_observation_to_index("obs:short")
+        dataset.add_observable_property(
+            observable_property_id="id_prop",
+            data_type=ObservablePropertyValueType.STRING,
+            element_label="id",
+            is_primary_key=True,
+        )
+        dataset.add_observable_property(
+            observable_property_id="measure_prop",
+            data_type=ObservablePropertyValueType.FLOAT,
+            element_label="left_measure",
+        )
+        dataset_series._register_observable_property(
+            "id_prop", "obs:ui", "source", "id"
+        )
+        dataset_series._register_observable_property(
+            "measure_prop", "obs:ui", "source", "left_measure"
+        )
+        dataset_series._register_observable_property(
+            "id_prop", "obs:short", "source", "id"
+        )
+        dataset_series._register_observable_property(
+            "measure_prop", "obs:short", "source", "left_measure"
+        )
+
+        left_data, _ = self.mixed_join_and_single_dataset_data()
+        dataset.data = adapter.subset(
+            left_data, element_group=["id", "left_measure"]
+        )
+
+        container = CacheContainerFactory.new()
+        container.add(
+            Observation(
+                id="obs:ui",
+                ui_label="friendly_observation",
+                short_name="short_observation",
+            )
+        )
+        container.add(Observation(id="obs:short", short_name="short_only"))
+        cache_view = CacheContainerView(container)
+
+        split_series = adapter.split_by_observation(
+            dataset_series, cache_view=cache_view
+        )
+
+        assert set(split_series.parts) == {
+            "friendly_observation",
+            "short_only",
+        }
+        assert split_series.context_lookup("obs:ui", "measure_prop")[0] == (
+            "friendly_observation"
+        )
+        assert split_series.context_lookup("obs:short", "measure_prop")[0] == (
+            "short_only"
+        )
+
+    def test_split_by_observation_rejects_duplicate_cache_labels(self):
+        adapter = self.get_adapter()
+        dataset_series = DatasetSeries(label="duplicate_label_split_case")
+        dataset = dataset_series.add_empty_dataset("source")
+        dataset.add_observation_to_index("obs:one")
+        dataset.add_observation_to_index("obs:two")
+        dataset.add_observable_property(
+            observable_property_id="id_prop",
+            data_type=ObservablePropertyValueType.STRING,
+            element_label="id",
+            is_primary_key=True,
+        )
+        dataset_series._register_observable_property(
+            "id_prop", "obs:one", "source", "id"
+        )
+        dataset_series._register_observable_property(
+            "id_prop", "obs:two", "source", "id"
+        )
+        left_data, _ = self.mixed_join_and_single_dataset_data()
+        dataset.data = adapter.subset(left_data, element_group=["id"])
+
+        container = CacheContainerFactory.new()
+        container.add(Observation(id="obs:one", ui_label="duplicate"))
+        container.add(Observation(id="obs:two", ui_label="duplicate"))
+        cache_view = CacheContainerView(container)
+
+        with pytest.raises(ValueError, match="must be unique"):
+            adapter.split_by_observation(dataset_series, cache_view=cache_view)
 
 
 class TestEnrichment(abc.ABC):

--- a/tests/core/session/test_session_resources.py
+++ b/tests/core/session/test_session_resources.py
@@ -262,11 +262,13 @@ class RecordingEnrichmentAdapter(DataEnrichmentInterface):
         dataset_series: DatasetSeries,
         *,
         new_label: str | None = None,
+        cache_view: CacheContainerView | None = None,
     ) -> DatasetSeries:
         self.calls.append(
             {
                 "dataset_series": dataset_series,
                 "new_label": new_label,
+                "cache_view": cache_view,
             }
         )
         return self._result
@@ -447,6 +449,8 @@ class TestSessionSplitDatasetSeriesByObservation:
         call = adapter.calls[0]
         assert call["dataset_series"] is source_dataset_series
         assert call["new_label"] == "custom_split"
+        assert isinstance(call["cache_view"], CacheContainerView)
+        assert call["cache_view"]._container is session.cache
 
     def test_split_dataset_series_by_observation_uses_default_label(self):
         session = get_session()
@@ -464,3 +468,5 @@ class TestSessionSplitDatasetSeriesByObservation:
         call = adapter.calls[0]
         assert call["dataset_series"] is source_dataset_series
         assert call["new_label"] is None
+        assert isinstance(call["cache_view"], CacheContainerView)
+        assert call["cache_view"]._container is session.cache


### PR DESCRIPTION
When splitting a DatasetSeries into Observation we now preferentially use the `ui_label`, then `short_name`, then `id` to label the resulting datasets.