### PR TITLE
migrate validation design

### DIFF
--- a/src/pypeh/core/interfaces/dataops.py
+++ b/src/pypeh/core/interfaces/dataops.py
@@ -1271,6 +1271,7 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
         dataset_schema_element: DatasetSchemaElement,
         type_annotations: dict[str, dict[str, ObservablePropertyValueType]],
         cache_view: CacheContainerView,
+        data_layout_element: peh.DataLayoutElement | None = None,
         dataset_label: str | None = None,
         column_has_only_empty_values: bool = False,
         allow_incomplete: bool = False,
@@ -1310,9 +1311,18 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
         if apply_property_validation:
             min_value = getattr(observable_property, "min", None)
             max_value = getattr(observable_property, "max", None)
-            if validation_designs := getattr(
-                observable_property, "validation_designs", None
-            ):
+            validation_designs = getattr(
+                data_layout_element, "validation_designs", None
+            )
+            if not validation_designs:
+                # LEGACY VALIDATION SUPPORT: remove this fallback when
+                # ObservableProperty.validation_designs is no longer supported.
+                # A DataLayoutElement with validation designs always takes
+                # precedence over property-owned designs.
+                validation_designs = getattr(
+                    observable_property, "validation_designs", None
+                )
+            if validation_designs:
                 validations.extend(
                     [
                         validation_dto.ValidationDesign.from_peh(
@@ -1414,6 +1424,18 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
         allow_incomplete: bool = False,
     ) -> list[validation_dto.ColumnValidation]:
         column_validations: list[validation_dto.ColumnValidation] = []
+        layout_section_id = dataset.described_by
+        layout_elements_by_label: dict[str, peh.DataLayoutElement] = {}
+        if layout_section_id is not None:
+            layout_section = cache_view.require(
+                layout_section_id, "DataLayoutSection"
+            )
+            assert isinstance(layout_section, peh.DataLayoutSection)
+            layout_elements_by_label = {
+                element.label: element
+                for element in layout_section.elements or []
+                if element.label is not None
+            }
         column_labels = dataset.get_element_labels()
         assert column_labels is not None
         for column_label in column_labels:
@@ -1435,6 +1457,7 @@ class ValidationInterface(DataOpsInterface, Generic[T_DataType]):
                 dataset_schema_element=dataset_schema_element,
                 cache_view=cache_view,
                 type_annotations=type_annotations,
+                data_layout_element=layout_elements_by_label.get(column_label),
                 dataset_label=dataset.label,
                 column_has_only_empty_values=column_has_only_empty_values,
                 allow_incomplete=allow_incomplete,

--- a/src/pypeh/core/models/internal_data_layout.py
+++ b/src/pypeh/core/models/internal_data_layout.py
@@ -292,9 +292,8 @@ class DatasetSchema:
         this_dataset: str,  # temporary fix
     ):
         """
-        ObservableProperties require context for:
-        - CalculationDesigns
-        - ValidationDesigns
+        LEGACY VALIDATION SUPPORT: remove this method with support for
+        ObservableProperty.validation_designs.
         """
         for schema_element in self.elements.values():
             observable_property_id = schema_element.observable_property_id

--- a/tests/core/interfaces/dataops/input/ValidationExamples/validation_test_03_corrected_config.yaml
+++ b/tests/core/interfaces/dataops/input/ValidationExamples/validation_test_03_corrected_config.yaml
@@ -89,6 +89,54 @@ layouts:
         label: peh:id_sample
     - label: chol
       observable_property: peh:chol
+      validation_designs:
+      - validation_expression:
+          validation_condition_expression:
+            validation_subject_contextual_field_references:
+            - dataset_label: SAMPLE
+              field_label: matrix
+            validation_command: is_in
+            validation_arg_values:
+            - BWB
+            - BP
+            - BS
+            - CBWB
+            - CBP
+            - CBS
+            - BWBG
+            - BPG
+            - BSG
+            - CBWBG
+            - CBPG
+            - CBSG
+            - DBS
+            - VAMS
+          validation_arg_expressions:
+          - validation_subject_contextual_field_references:
+            - dataset_label: SAMPLETIMEPOINT_BSS
+              field_label: chol
+            validation_command: is_greater_than_or_equal_to
+            validation_arg_values:
+            - '50'
+        conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS) THEN chol IS not empty; IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS) THEN chol [50,250]; IF matrix IS (BM,BMG) THEN chol [5,100]"
+        validation_error_message_template: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS) THEN chol IS not empty; IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS) THEN chol [50,250]; IF matrix IS (BM,BMG) THEN chol [5,100]"
+      - validation_expression:
+          validation_condition_expression:
+            validation_subject_contextual_field_references:
+            - dataset_label: SAMPLE
+              field_label: matrix
+            validation_command: is_in
+            validation_arg_values:
+            - BM
+            - BMG
+          validation_arg_expressions:
+          - validation_subject_contextual_field_references:
+            - dataset_label: SAMPLETIMEPOINT_BSS
+              field_label: chol
+            validation_command: is_greater_than_or_equal_to
+            validation_arg_values:
+            - '5'
+        conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS) THEN chol IS not empty; IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS) THEN chol [50,250]; IF matrix IS (BM,BMG) THEN chol [5,100]"
     - label: chol_lod
       observable_property: peh:chol_lod
     - label: chol_loq
@@ -221,56 +269,6 @@ observable_properties:
   relevant_observation_types:
   - questionnaire
   short_name: chol
-  validation_designs:
-  - validation_expression:
-      validation_condition_expression:
-        validation_subject_contextual_field_references:
-        - field_label: peh:matrix
-        validation_command: is_in
-        validation_arg_values:
-        - BWB
-        - BP
-        - BS
-        - CBWB
-        - CBP
-        - CBS
-        - BWBG
-        - BPG
-        - BSG
-        - CBWBG
-        - CBPG
-        - CBSG
-        - DBS
-        - VAMS
-      validation_arg_expressions:
-      - validation_subject_contextual_field_references:
-        - field_label: peh:chol
-        validation_command: is_greater_than_or_equal_to
-        validation_arg_values:
-        - '50'
-    conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS)\
-      \  THEN chol IS not empty; \n\nIF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS)\
-      \  THEN chol [50,250]; \n\nIF matrix IS (BM,BMG)  THEN chol [5,100]"
-    validation_error_message_template: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS)\
-      \  THEN chol IS not empty; \n\nIF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS)\
-      \  THEN chol [50,250]; \n\nIF matrix IS (BM,BMG)  THEN chol [5,100]"
-  - validation_expression:
-      validation_condition_expression:
-        validation_subject_contextual_field_references:
-        - field_label: peh:matrix
-        validation_command: is_in
-        validation_arg_values:
-        - BM
-        - BMG
-      validation_arg_expressions:
-      - validation_subject_contextual_field_references:
-        - field_label: peh:chol
-        validation_command: is_greater_than_or_equal_to
-        validation_arg_values:
-        - '5'
-    conditional: "IF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BM,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,BMG,DBS,VAMS)\
-      \  THEN chol IS not empty; \n\nIF matrix IS (BWB,BP,BS,CBWB,CBP,CBS,BWBG,BPG,BSG,CBWBG,CBPG,CBSG,DBS,VAMS)\
-      \  THEN chol [50,250]; \n\nIF matrix IS (BM,BMG)  THEN chol [5,100]"
 - id: peh:chol_lod
   name: chol_lod
   description: lod associated with the cholesterol measurement of the sample

--- a/tests/core/interfaces/dataops/test_dataops.py
+++ b/tests/core/interfaces/dataops/test_dataops.py
@@ -2,6 +2,7 @@ import pytest
 import abc
 import importlib
 import re
+import peh_model.peh as peh
 
 from datetime import date
 from typing import Protocol, Generic
@@ -140,6 +141,17 @@ class TestValidation(abc.ABC):
         src_path = "./input/ValidationExamples/validation_test_03_corrected_config.yaml"
         cache_view = self.get_container(src_path)
         return cache_view
+
+    @staticmethod
+    def get_data_layout_element(cache_view, dataset, element_label):
+        layout_section = cache_view.require(
+            dataset.described_by, "DataLayoutSection"
+        )
+        return next(
+            element
+            for element in layout_section.elements
+            if element.label == element_label
+        )
 
     def test_getting_default_adapter_from_interface(self):
         adapter_class = ValidationInterface.get_default_adapter_class()
@@ -541,7 +553,7 @@ class TestValidation(abc.ABC):
         )
         assert isinstance(data_layout, DataLayout)
         dataset_series = DatasetSeries.from_peh_datalayout(
-            data_layout=data_layout, cache_view=cache_view, apply_context=True
+            data_layout=data_layout, cache_view=cache_view
         )
         dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
         assert dataset is not None
@@ -560,7 +572,7 @@ class TestValidation(abc.ABC):
         )
         assert isinstance(data_layout, DataLayout)
         dataset_series = DatasetSeries.from_peh_datalayout(
-            data_layout=data_layout, cache_view=cache_view, apply_context=True
+            data_layout=data_layout, cache_view=cache_view
         )
         dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
         assert dataset is not None
@@ -582,7 +594,7 @@ class TestValidation(abc.ABC):
         )
         assert isinstance(data_layout, DataLayout)
         dataset_series = DatasetSeries.from_peh_datalayout(
-            data_layout=data_layout, cache_view=cache_view, apply_context=True
+            data_layout=data_layout, cache_view=cache_view
         )
         type_annotations = dataset_series.get_type_annotations()
         dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
@@ -592,6 +604,9 @@ class TestValidation(abc.ABC):
             dataset_schema_element=dataset_schema_element,
             type_annotations=type_annotations,
             cache_view=cache_view,
+            data_layout_element=self.get_data_layout_element(
+                cache_view, dataset, "chol"
+            ),
         )
         assert cv.validations is not None
         collect_messages = [
@@ -601,6 +616,94 @@ class TestValidation(abc.ABC):
         found = any(re.search(pattern, msg) for msg in collect_messages)
         assert found
 
+    def test_data_layout_element_validation_designs_take_precedence(self):
+        adapter = self.get_adapter()
+        cache_view = self.get_container_validation_example_03()
+        data_layout = cache_view.get(
+            "peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA", "DataLayout"
+        )
+        dataset_series = DatasetSeries.from_peh_datalayout(
+            data_layout=data_layout, cache_view=cache_view
+        )
+        dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
+        assert dataset is not None
+        schema_element = dataset.get_schema_element_by_label("chol")
+        assert schema_element is not None
+        observable_property = cache_view.get(
+            schema_element.observable_property_id, "ObservableProperty"
+        )
+        observable_property.validation_designs = [
+            peh.ValidationDesign(
+                validation_name="legacy_property_rule",
+                validation_expression=peh.ValidationExpression(
+                    validation_command="is_null"
+                ),
+            )
+        ]
+        data_layout_element = self.get_data_layout_element(
+            cache_view, dataset, "chol"
+        )
+        data_layout_element.validation_designs = [
+            peh.ValidationDesign(
+                validation_name="layout_element_rule",
+                validation_expression=peh.ValidationExpression(
+                    validation_command="is_not_null"
+                ),
+            )
+        ]
+
+        column_validation = adapter.build_column_validation(
+            dataset_schema_element=schema_element,
+            type_annotations=dataset_series.get_type_annotations(),
+            cache_view=cache_view,
+            data_layout_element=data_layout_element,
+            dataset_label=dataset.label,
+        )
+
+        validation_names = {
+            validation.name for validation in column_validation.validations
+        }
+        assert "layout_element_rule" in validation_names
+        assert "legacy_property_rule" not in validation_names
+
+    def test_legacy_observable_property_validation_designs_are_supported(self):
+        """Remove with legacy ObservableProperty validation support."""
+        adapter = self.get_adapter()
+        cache_view = self.get_container_validation_example_03()
+        data_layout = cache_view.get(
+            "peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA", "DataLayout"
+        )
+        dataset_series = DatasetSeries.from_peh_datalayout(
+            data_layout=data_layout, cache_view=cache_view
+        )
+        dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")
+        assert dataset is not None
+        schema_element = dataset.get_schema_element_by_label("chol")
+        assert schema_element is not None
+        observable_property = cache_view.get(
+            schema_element.observable_property_id, "ObservableProperty"
+        )
+        observable_property.validation_designs = [
+            peh.ValidationDesign(
+                validation_name="legacy_property_rule",
+                validation_expression=peh.ValidationExpression(
+                    validation_command="is_not_null"
+                ),
+            )
+        ]
+
+        column_validation = adapter.build_column_validation(
+            dataset_schema_element=schema_element,
+            type_annotations=dataset_series.get_type_annotations(),
+            cache_view=cache_view,
+            dataset_label=dataset.label,
+        )
+
+        assert any(
+            validation.name == "legacy_property_rule"
+            for validation in column_validation.validations
+        )
+
     def test_build_column_validation_from_observable_property_bounds(self):
         adapter = self.get_adapter()
         cache_view = self.get_container_validation_example_03()
@@ -609,7 +712,7 @@ class TestValidation(abc.ABC):
         )
         assert isinstance(data_layout, DataLayout)
         dataset_series = DatasetSeries.from_peh_datalayout(
-            data_layout=data_layout, cache_view=cache_view, apply_context=True
+            data_layout=data_layout, cache_view=cache_view
         )
         type_annotations = dataset_series.get_type_annotations()
         dataset = dataset_series.get("SAMPLETIMEPOINT_BSS")

--- a/tests/core/models/test_internal_datalayout.py
+++ b/tests/core/models/test_internal_datalayout.py
@@ -296,7 +296,10 @@ class TestInternalDataLayout:
             "subject_id",
         )
 
-    def test_apply_context(self, get_cache):
+    def test_legacy_observable_property_validation_apply_context(
+        self, get_cache
+    ):
+        """Remove with legacy ObservableProperty validation support."""
         cache_view = get_cache
         layout_id = "peh:CODEBOOK_v2.4_LAYOUT_SAMPLE_METADATA"
         layout = get_cache.get(layout_id, "DataLayoutLayout")


### PR DESCRIPTION
Migrates `ObservableProperty`-level validation designs to `DataLayoutSectionElement`.